### PR TITLE
Add backend npm install instruction

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -27,8 +27,10 @@
 
 ## Project setup
 
+Run the following from the `backend` directory to install the Node.js dependencies:
+
 ```bash
-$ npm install
+npm install
 ```
 
 ## Compile and run the project


### PR DESCRIPTION
## Summary
- clarify dependency installation steps in backend README

## Testing
- `npm test` *(fails: Cannot find module '../../generated/prisma')*
- `npm run test:e2e` *(fails: Cannot find module '../../generated/prisma')*

------
https://chatgpt.com/codex/tasks/task_e_684b6d46bff0832788952cbbcf044973