### PR TITLE
Add guidance for frontend package conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@
 $ npm install
 ```
 
+## Frontend setup
+
+If you are working on the optional `frontend` folder, note that certain
+packages such as `@chainsafe/circle-react-elements` require Tailwind CSS 4.x.
+If you see an `ERESOLVE unable to resolve dependency tree` error during
+installation, update `tailwindcss` to a 4.x version or run npm with
+`--legacy-peer-deps`.
+
 ## Compile and run the project
 
 ```bash


### PR DESCRIPTION
## Summary
- document how to resolve `tailwindcss` peer dependency issues for the optional frontend

## Testing
- `npm test` *(fails: cannot find module '../../generated/prisma')*

------
https://chatgpt.com/codex/tasks/task_e_68479bb8bd1483278f57591a7b446dc8