### PR TITLE
Add Gemini hashtag generator

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,25 +9,26 @@ import { MailerModule } from '@nestjs-modules/mailer';
 
 // Główne moduły aplikacji
 import { AppController } from './app.controller'; // Zakładając, że masz ten plik
-import { AppService } from './app.service';     // Zakładając, że masz ten plik
-import { PrismaModule } from './prisma/prisma.module';   // Twój moduł Prisma
-import { AuthModule } from './auth/auth.module';       // Twój moduł Auth
-import { UsersModule } from './users/users.module';     // Twój moduł Users
-import { CircleModule } from './circle/circle.module';   // Twój moduł Circle
-import { TipsModule } from './tips/tips.module';    // Moduł Napiwków
+import { AppService } from './app.service'; // Zakładając, że masz ten plik
+import { PrismaModule } from './prisma/prisma.module'; // Twój moduł Prisma
+import { AuthModule } from './auth/auth.module'; // Twój moduł Auth
+import { UsersModule } from './users/users.module'; // Twój moduł Users
+import { CircleModule } from './circle/circle.module'; // Twój moduł Circle
+import { TipsModule } from './tips/tips.module'; // Moduł Napiwków
 import { RedisModule } from './shared/redis/redis.module'; // Załóżmy, że masz ten moduł i jest on @Global
+import { GeneratorModule } from './generator/generator.module';
 
 @Module({
   imports: [
     // 1. ConfigModule jako pierwszy, aby zmienne .env były dostępne wszędzie
     ConfigModule.forRoot({
-      isGlobal: true,      // Udostępnia ConfigService w całej aplikacji
+      isGlobal: true, // Udostępnia ConfigService w całej aplikacji
       envFilePath: '.env', // Ścieżka do pliku .env (z głównego katalogu backendu)
     }),
 
     // 2. Twoje globalne moduły serwisowe
     PrismaModule, // Zakładając, że PrismaModule jest @Global
-    RedisModule,  // Zakładając, że RedisModule jest @Global (potrzebny dla AuthModulex)
+    RedisModule, // Zakładając, że RedisModule jest @Global (potrzebny dla AuthModulex)
 
     // === DODAJ KONFIGURACJĘ MAILERMODULE TUTAJ ===
     MailerModule.forRootAsync({
@@ -61,12 +62,13 @@ import { RedisModule } from './shared/redis/redis.module'; // Załóżmy, że ma
     // ============================================
 
     // 3. Moduły poszczególnych funkcjonalności aplikacji
-    AuthModule,    // AuthModule będzie teraz mógł importować MailerModule (bez .forRootAsync)
+    AuthModule, // AuthModule będzie teraz mógł importować MailerModule (bez .forRootAsync)
     UsersModule,
     CircleModule,
     TipsModule,
+    GeneratorModule,
   ],
   controllers: [AppController], // Jeśli masz AppController
-  providers: [AppService],   // Jeśli masz AppService
+  providers: [AppService], // Jeśli masz AppService
 })
 export class AppModule {}

--- a/backend/src/generator/dto.ts
+++ b/backend/src/generator/dto.ts
@@ -1,0 +1,15 @@
+import { IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class GenerateHashtagsDto {
+  @IsString()
+  @IsNotEmpty()
+  topic: string;
+
+  @IsString()
+  @IsIn(['instagram', 'twitter', 'facebook', 'linkedin'])
+  platform: string;
+
+  @IsString()
+  @IsOptional()
+  generator?: string;
+}

--- a/backend/src/generator/generator.controller.ts
+++ b/backend/src/generator/generator.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { GeneratorService } from './generator.service';
+import { GenerateHashtagsDto } from './dto';
+
+@Controller('generate')
+export class GeneratorController {
+  constructor(private readonly generatorService: GeneratorService) {}
+
+  @Post('hashtags')
+  async generateHashtags(@Body() dto: GenerateHashtagsDto) {
+    const hashtags = await this.generatorService.generateHashtags(
+      dto.topic,
+      dto.platform,
+      dto.generator,
+    );
+    return { hashtags };
+  }
+}

--- a/backend/src/generator/generator.module.ts
+++ b/backend/src/generator/generator.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { GeneratorService } from './generator.service';
+import { GeneratorController } from './generator.controller';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [GeneratorController],
+  providers: [GeneratorService],
+  exports: [GeneratorService],
+})
+export class GeneratorModule {}

--- a/backend/src/generator/generator.service.ts
+++ b/backend/src/generator/generator.service.ts
@@ -1,0 +1,67 @@
+import {
+  Injectable,
+  Logger,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class GeneratorService {
+  private readonly logger = new Logger(GeneratorService.name);
+  private readonly geminiApiKey: string;
+
+  constructor(private configService: ConfigService) {
+    this.geminiApiKey = this.configService.get<string>('GEMINI_API_KEY', '');
+  }
+
+  async generateHashtags(
+    topic: string,
+    platform: string,
+    generator = 'gemini',
+  ): Promise<string[]> {
+    if (generator !== 'gemini') {
+      this.logger.warn(
+        `Unknown generator ${generator}, falling back to gemini`,
+      );
+    }
+    if (!this.geminiApiKey) {
+      this.logger.error('GEMINI_API_KEY not configured');
+      throw new InternalServerErrorException('Generator not available');
+    }
+    const prompt = `Podaj 5 hasztagów na platformę ${platform} dotyczących tematu: ${topic}. Zwróć je w jednym wierszu, oddzielone przecinkami.`;
+    try {
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${this.geminiApiKey}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            contents: [{ parts: [{ text: prompt }] }],
+          }),
+        },
+      );
+      if (!response.ok) {
+        this.logger.error(
+          `Gemini API error: ${response.status} ${response.statusText}`,
+        );
+        throw new InternalServerErrorException('Generator API error');
+      }
+      const data = await response.json();
+      const text: string | undefined =
+        data?.candidates?.[0]?.content?.parts?.[0]?.text;
+      if (!text) {
+        this.logger.error('Invalid response from Gemini API');
+        throw new InternalServerErrorException(
+          'Generator API invalid response',
+        );
+      }
+      return text
+        .split(/[,\n]/)
+        .map((s: string) => s.trim())
+        .filter((s: string) => s.length > 0);
+    } catch (err) {
+      this.logger.error(`Error calling Gemini API: ${(err as Error).message}`);
+      throw new InternalServerErrorException('Generator API request failed');
+    }
+  }
+}

--- a/frontend/src/app/generator/page.tsx
+++ b/frontend/src/app/generator/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+
+const PLATFORMS = ['instagram', 'twitter', 'facebook', 'linkedin'];
+
+export default function GeneratorPage() {
+  const [topic, setTopic] = useState('');
+  const [platform, setPlatform] = useState(PLATFORMS[0]);
+  const [hashtags, setHashtags] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/generate/hashtags`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ topic, platform }),
+      });
+      if (!res.ok) throw new Error('API error');
+      const data = await res.json();
+      setHashtags(data.hashtags || []);
+    } catch {
+      setError('Błąd podczas pobierania hashtagów');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Generator Hashtagów</h1>
+      <form onSubmit={submit} className="space-y-4">
+        <input
+          type="text"
+          value={topic}
+          onChange={(e) => setTopic(e.target.value)}
+          placeholder="Temat"
+          required
+          className="w-full border p-2 rounded"
+        />
+        <select
+          value={platform}
+          onChange={(e) => setPlatform(e.target.value)}
+          className="w-full border p-2 rounded"
+        >
+          {PLATFORMS.map((p) => (
+            <option key={p} value={p}>{p}</option>
+          ))}
+        </select>
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          Generuj
+        </button>
+      </form>
+      {error && <p className="text-red-600 mt-4">{error}</p>}
+      {hashtags.length > 0 && (
+        <motion.ul
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="mt-4 space-y-2"
+        >
+          {hashtags.map((h) => (
+            <li key={h} className="bg-gray-100 p-2 rounded">{h}</li>
+          ))}
+        </motion.ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add GeneratorModule with Gemini API integration
- expose `/generate/hashtags` endpoint
- create basic front-end UI for generating hashtags

## Testing
- `npm run lint` within `frontend`
- `npm run lint` within `backend` *(fails: Async method 'useFactory' has no 'await' expression and other issues)*
- `npm test` within `backend` *(fails: cannot find module '../../generated/prisma')*
- `npm test` within `frontend` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_686099275ee08327a15f3fde940608dc