### PR TITLE
Add dynamic creator page and OG improvements

### DIFF
--- a/frontend/public/fallback-jar.svg
+++ b/frontend/public/fallback-jar.svg
@@ -1,0 +1,4 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="30" width="80" height="70" rx="15" ry="15" fill="#006D6D" stroke="#FFD700" stroke-width="8"/>
+  <rect x="30" y="20" width="60" height="15" fill="#FFD700"/>
+</svg>

--- a/frontend/src/app/@[handle]/page.tsx
+++ b/frontend/src/app/@[handle]/page.tsx
@@ -1,0 +1,39 @@
+import { Metadata } from 'next';
+import { getCreatorProfile } from '@/lib/api';
+
+export async function generateMetadata({ params }: { params: { handle: string } }): Promise<Metadata> {
+  const profile = await getCreatorProfile(params.handle);
+  return {
+    title: `Support @${params.handle} on TipJar+`,
+    description: profile.goal || 'Send tips in USDC to support this creator directly.',
+    openGraph: {
+      title: `Support @${params.handle} on TipJar+`,
+      images: [`https://tipjar.plus/api/og?handle=${params.handle}&goal=${encodeURIComponent(profile.goal || '')}`],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      images: [`https://tipjar.plus/api/og?handle=${params.handle}&goal=${encodeURIComponent(profile.goal || '')}`],
+    },
+  };
+}
+
+export default async function CreatorPage({ params }: { params: { handle: string } }) {
+  const profile = await getCreatorProfile(params.handle);
+
+  return (
+    <main className="max-w-3xl mx-auto py-12 px-4 text-white">
+      <div className="flex items-center gap-4 mb-6">
+        <img
+          src={profile.avatarUrl || '/fallback-jar.svg'}
+          alt={`@${params.handle}`}
+          className="w-24 h-24 rounded-full border-4 border-[#FFD700] shadow-md shadow-yellow-400"
+          onError={(e) => (e.currentTarget.src = '/fallback-jar.svg')}
+        />
+        <div>
+          <h1 className="text-3xl font-bold">@{params.handle}</h1>
+          {profile.goal && <p className="text-lg text-gold mt-1">🎯 {profile.goal}</p>}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/api/og/route.tsx
+++ b/frontend/src/app/api/og/route.tsx
@@ -1,54 +1,55 @@
 /* eslint-disable @next/next/no-img-element */
-import { ImageResponse } from '@vercel/og'
-import React from 'react'
+import { ImageResponse } from 'next/og'
+import { NextRequest } from 'next/server'
 
 export const runtime = 'edge'
 
-export async function GET(req: Request) {
+export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url)
 
-  const handle = searchParams.get('handle') ?? 'creator'
-  const goal   = searchParams.get('goal')   ?? 'Support me on TipJar+'
-
-  // ⚡ SVG jako string, potem enkodujemy do data-URL
-  const avatarSVG = `
-    <svg width="160" height="160" viewBox="0 0 160 160" fill="none"
-         xmlns="http://www.w3.org/2000/svg">
-      <circle cx="80" cy="80" r="75" stroke="#FFD700" stroke-width="10" fill="none"/>
-    </svg>`
-  const avatar = `data:image/svg+xml;utf8,${encodeURIComponent(avatarSVG)}`
+  const handle = searchParams.get('handle') || 'anon'
+  const goal = searchParams.get('goal') || ''
 
   return new ImageResponse(
     (
       <div
         style={{
-          width: 1200,
-          height: 630,
           display: 'flex',
-          alignItems: 'center',
-          background: '#0d2f3f',
+          height: '100%',
+          width: '100%',
+          backgroundColor: '#006D6D',
           color: '#FFD700',
-          padding: 40,
-          fontSize: 32,
-          fontFamily: 'Inter, sans-serif',
+          padding: '40px',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          fontFamily: 'Montserrat',
         }}
       >
-        <img
-          src={avatar}
-          alt="Avatar"
-          width={160}
-          height={160}
-          style={{ borderRadius: '50%', marginRight: 40 }}
-        />
-        <div style={{ display: 'flex', flexDirection: 'column', color: 'white' }}>
-          <b>{`Support @${handle} on TipJar+`}</b>
-          {goal}
-          <span style={{ fontSize: 24 }}>
-            Send tips in&nbsp;USDC – no login required.
-          </span>
+        <div style={{ fontSize: 40, marginBottom: 20 }}>🎁 Support @{handle}</div>
+        {goal && (
+          <div
+            style={{
+              fontSize: 28,
+              color: 'white',
+              backgroundColor: '#008080',
+              padding: '10px 20px',
+              borderRadius: 12,
+              maxWidth: 600,
+              textAlign: 'center',
+            }}
+          >
+            Goal: {goal}
+          </div>
+        )}
+        <div style={{ marginTop: 32, fontSize: 24, color: '#ffffff' }}>
+          tipjar.plus/@{handle}
         </div>
       </div>
     ),
-    { width: 1200, height: 630 },
+    {
+      width: 1200,
+      height: 630,
+    }
   )
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,21 @@
+export interface CreatorProfile {
+  avatarUrl?: string | null;
+  goal?: string | null;
+}
+
+export async function getCreatorProfile(handle: string): Promise<CreatorProfile> {
+  // Placeholder implementation fetching from a future API
+  try {
+    const res = await fetch(`/api/profile?handle=${encodeURIComponent(handle)}`);
+    if (res.ok) {
+      const data = await res.json();
+      return {
+        avatarUrl: data.avatarUrl ?? null,
+        goal: data.goal ?? null,
+      };
+    }
+  } catch {
+    // ignore errors and fall back to mock
+  }
+  return { avatarUrl: null, goal: null };
+}


### PR DESCRIPTION
## Summary
- add `getCreatorProfile` helper and fallback avatar SVG
- add dynamic page for `@<handle>`
- modernize OG image route for brand styling

## Testing
- `npm run lint` in `frontend`
- `npm run lint` in `backend` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68688d62456083279792033b05bc7b21