### PR TITLE
Add token generation test

### DIFF
--- a/backend/generated/prisma/index.ts
+++ b/backend/generated/prisma/index.ts
@@ -1,0 +1,19 @@
+export class PrismaClient {
+  [key: string]: any;
+  constructor(options?: any) {}
+  async $connect(): Promise<void> {}
+  async $disconnect(): Promise<void> {}
+}
+
+export enum UserRole {
+  FAN = 'FAN',
+  CREATOR = 'CREATOR',
+  ADMIN = 'ADMIN'
+}
+
+export type User = any;
+export type SocialConnection = any;
+export const Prisma = {} as any;
+export namespace Prisma {
+  export type UserCreateInput = any;
+}

--- a/backend/src/auth/auth.controller.spec.ts
+++ b/backend/src/auth/auth.controller.spec.ts
@@ -1,5 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { SiweVerifier } from './strategies/siwe.verifier';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -7,6 +11,12 @@ describe('AuthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
+      providers: [
+        { provide: AuthService, useValue: {} },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: JwtService, useValue: {} },
+        { provide: SiweVerifier, useValue: {} },
+      ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,12 +1,26 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AuthService } from './auth.service';
+import { AuthService, ValidatedUser } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { CircleService } from '../circle/circle.service';
+import { MailerService } from '@nestjs-modules/mailer';
+import { UserRole } from '../../generated/prisma';
 
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        { provide: UsersService, useValue: { updateUser: jest.fn() } },
+        { provide: JwtService, useValue: { sign: jest.fn(() => 'token') } },
+        { provide: ConfigService, useValue: { get: jest.fn(() => 'secret') } },
+        { provide: CircleService, useValue: {} },
+        { provide: MailerService, useValue: {} },
+        { provide: 'REDIS_CLIENT', useValue: {} },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
@@ -14,5 +28,20 @@ describe('AuthService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should generate tokens', async () => {
+    const user: ValidatedUser = {
+      id: '1',
+      email: 'test@example.com',
+      role: UserRole.FAN,
+      displayName: 'Test',
+      isEmailVerified: true,
+      isActive: true,
+    };
+
+    const tokens = await (service as any)['generateTokens'](user);
+    expect(typeof tokens.accessToken).toBe('string');
+    expect(typeof tokens.refreshToken).toBe('string');
   });
 });


### PR DESCRIPTION
## Summary
- provide minimal Prisma stubs for tests
- mock AuthService & AuthController dependencies in their specs
- add unit test to cover token generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68446e9281908327aa4c726d7a3fe273