### PR TITLE
Add payouts backend module

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -26,6 +26,13 @@ enum TipStatus {
   REFUNDED   // Zwrócony (jeśli taka opcja będzie)
 }
 
+enum PayoutStatus {
+  PENDING
+  PROCESSING
+  COMPLETED
+  FAILED
+}
+
 // --- Modele Danych ---
 
 model User {
@@ -146,4 +153,20 @@ model OverlaySettings {
   soundEffectUrl         String?
 
   creator User @relation(fields: [creatorId], references: [id])
+}
+
+model Payout {
+  id                   String       @id @default(uuid())
+  creatorId            String
+  creator              User         @relation(fields: [creatorId], references: [id])
+  amount               Decimal
+  currency             String       @default("USDC")
+  destinationAddress   String
+  circleTransactionId  String?      @unique
+  status               PayoutStatus @default(PENDING)
+  requestedAt          DateTime     @default(now())
+  processedAt          DateTime?
+  failureReason        String?
+
+  @@index([creatorId])
 }

--- a/backend/src/@types/prisma-client.d.ts
+++ b/backend/src/@types/prisma-client.d.ts
@@ -11,5 +11,12 @@ declare module '@prisma/client' {
     CREATOR = 'CREATOR',
     ADMIN = 'ADMIN'
   }
+  export enum PayoutStatus {
+    PENDING = 'PENDING',
+    PROCESSING = 'PROCESSING',
+    COMPLETED = 'COMPLETED',
+    FAILED = 'FAILED'
+  }
   export type Tip = any;
+  export type Payout = any;
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,12 @@ import { AppController } from './app.controller'; // Zakładając, że masz ten 
 
 import { RedisModule } from './shared/redis/redis.module'; // Załóżmy, że masz ten moduł i jest on @Global
 import { GeneratorModule } from './generator/generator.module';
+import { PrismaModule } from './prisma/prisma.module';
+import { AuthModule } from './auth/auth.module';
+import { UsersModule } from './users/users.module';
+import { CircleModule } from './circle/circle.module';
+import { TipsModule } from './tips/tips.module';
+import { PayoutsModule } from './payouts/payouts.module';
 
 @Module({
   imports: [
@@ -61,6 +67,7 @@ import { GeneratorModule } from './generator/generator.module';
     UsersModule,
     CircleModule,
     TipsModule,
+    PayoutsModule,
 
   ],
   controllers: [AppController], // Jeśli masz AppController

--- a/backend/src/payouts/dto/create-payout.dto.ts
+++ b/backend/src/payouts/dto/create-payout.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsNotEmpty, IsDecimal } from 'class-validator';
+
+export class CreatePayoutDto {
+  @IsDecimal({ decimal_digits: '2,6' })
+  @IsNotEmpty()
+  amount!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  destinationAddress!: string;
+}

--- a/backend/src/payouts/payouts.controller.ts
+++ b/backend/src/payouts/payouts.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Post, Body, UseGuards, Req, HttpCode, HttpStatus } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { PayoutsService } from './payouts.service';
+import { CreatePayoutDto } from './dto/create-payout.dto';
+import { Request } from 'express';
+import { ValidatedUser } from '../auth/auth.service';
+import { Payout } from '@prisma/client';
+
+@Controller('creator')
+export class PayoutsController {
+  constructor(private readonly payoutsService: PayoutsService) {}
+
+  @Post('payout')
+  @UseGuards(AuthGuard('jwt'))
+  @HttpCode(HttpStatus.CREATED)
+  createPayout(@Req() req: Request, @Body() dto: CreatePayoutDto): Promise<Payout> {
+    const user = req.user as ValidatedUser;
+    return this.payoutsService.createPayout(user.id, dto.amount, dto.destinationAddress);
+  }
+}

--- a/backend/src/payouts/payouts.module.ts
+++ b/backend/src/payouts/payouts.module.ts
@@ -1,0 +1,14 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { PayoutsService } from './payouts.service';
+import { PayoutsController } from './payouts.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+import { CircleModule } from '../circle/circle.module';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [PrismaModule, ConfigModule, forwardRef(() => CircleModule)],
+  controllers: [PayoutsController],
+  providers: [PayoutsService],
+  exports: [PayoutsService],
+})
+export class PayoutsModule {}

--- a/backend/src/payouts/payouts.service.ts
+++ b/backend/src/payouts/payouts.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger, NotFoundException, Inject, forwardRef } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CircleService } from '../circle/circle.service';
+import { Payout, PayoutStatus } from '@prisma/client';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class PayoutsService {
+  private readonly logger = new Logger(PayoutsService.name);
+
+  constructor(
+    private prisma: PrismaService,
+    private configService: ConfigService,
+    @Inject(forwardRef(() => CircleService)) private circleService: CircleService,
+  ) {}
+
+  async createPayout(creatorId: string, amount: string, destinationAddress: string): Promise<Payout> {
+    const creator = await this.prisma.user.findUnique({ where: { id: creatorId } });
+    if (!creator || !creator.circleWalletId) {
+      throw new NotFoundException('Creator wallet not configured');
+    }
+
+    const payout = await this.prisma.payout.create({
+      data: {
+        creatorId,
+        amount,
+        destinationAddress,
+        status: PayoutStatus.PENDING,
+      },
+    });
+
+    try {
+      const blockchain = this.configService.get<string>('DEFAULT_BLOCKCHAIN', 'MATIC-AMOY');
+      const tokenId = this.configService.get<string>('USDC_TOKEN_ID', 'USDC');
+      const res = await this.circleService.initiateWithdrawal(
+        creatorId,
+        destinationAddress,
+        amount,
+        blockchain as any,
+        tokenId,
+      );
+
+      await this.prisma.payout.update({
+        where: { id: payout.id },
+        data: {
+          circleTransactionId: res.circleTransactionId,
+          status: PayoutStatus.PROCESSING,
+        },
+      });
+    } catch (err) {
+      this.logger.error(`Payout ${payout.id} failed to initiate`, err as Error);
+      await this.prisma.payout.update({
+        where: { id: payout.id },
+        data: { status: PayoutStatus.FAILED },
+      });
+      throw err;
+    }
+
+    return this.prisma.payout.findUnique({ where: { id: payout.id } }) as Promise<Payout>;
+  }
+}


### PR DESCRIPTION
## Summary
- extend Prisma schema with `PayoutStatus` enum and `Payout` model
- add typings for new enum and model
- implement `payouts` NestJS module with service, controller and DTO
- register new module in `AppModule`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68689ae7380083278c64253040e8e59f