### PR TITLE
Add DTOs and update controller types

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -13,11 +13,11 @@ import { User as UserModel, UserRole } from '../../generated/prisma';// Model Us
 
 // Załóżmy, że DTOs są zdefiniowane w folderze src/auth/dto/
 // Należy je utworzyć i odkomentować importy oraz użycie.
-// import { RegisterUserDto } from './dto/register-user.dto';
+import { RegisterUserDto } from './dto/register-user.dto';
 // import { LoginUserDto } from './dto/login-user.dto';
-// import { SiweRequestNonceDto } from './dto/siwe-request-nonce.dto';
-// import { SiweVerifySignatureDto } from './dto/siwe-verify-signature.dto';
-// import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { SiweRequestNonceDto } from './dto/siwe-request-nonce.dto';
+import { SiweVerifySignatureDto } from './dto/siwe-verify-signature.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
 
 
 @Controller('auth') // Globalny prefix /api/v1/auth (zdefiniowany w main.ts)
@@ -70,7 +70,7 @@ export class AuthController {
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
   async register(
-    @Body() registerUserDto: any, // TODO: Zastąp 'any' przez faktyczne RegisterUserDto
+    @Body() registerUserDto: RegisterUserDto,
     @Res({ passthrough: true }) response: Response, // passthrough: true, aby NestJS nadal wysłał odpowiedź
   ): Promise<{ message: string; user: Omit<ValidatedUser, 'password' /* jeśli ValidatedUser zawierałoby hasło */> }> {
     this.logger.log(`Registration attempt initiated for email: ${registerUserDto.email}`);
@@ -134,7 +134,7 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   async refreshToken(
     @Req() req: Request, // Do odczytu ciasteczka refresh_token
-    @Body() body: { refreshToken?: string }, // Alternatywnie, jeśli frontend wysyła w ciele
+    @Body() body: RefreshTokenDto, // Alternatywnie, jeśli frontend wysyła w ciele
     @Res({ passthrough: true }) response: Response,
   ): Promise<{ accessToken: string }> {
     const incomingRefreshToken = req.cookies?.['refresh_token'] || body.refreshToken;
@@ -233,7 +233,7 @@ export class AuthController {
   // --- Endpointy dla SIWE (Sign-In with Ethereum) ---
   @Post('siwe/nonce')
   @HttpCode(HttpStatus.OK)
-  async getSiweNonce(@Body() body: { address: string } /* TODO: Zastąp przez SiweRequestNonceDto */): Promise<{ nonce: string }> {
+  async getSiweNonce(@Body() body: SiweRequestNonceDto): Promise<{ nonce: string }> {
     if (!body.address /* || !isEthereumAddress(body.address) - dodaj walidację przez DTO */) {
       throw new BadRequestException('Adres portfela jest wymagany i musi być poprawny.');
     }
@@ -245,7 +245,7 @@ export class AuthController {
   @Post('siwe/verify')
   @HttpCode(HttpStatus.OK)
   async verifySiweSignature(
-    @Body() siweVerifyDto: any, // TODO: Zastąp przez SiweVerifySignatureDto (message, signature, address)
+    @Body() siweVerifyDto: SiweVerifySignatureDto,
     @Res({ passthrough: true }) response: Response,
   ): Promise<{ message: string; user: ValidatedUser; accessToken: string }> {
     const { message, signature, address } = siweVerifyDto;

--- a/backend/src/auth/dto/refresh-token.dto.ts
+++ b/backend/src/auth/dto/refresh-token.dto.ts
@@ -1,8 +1,8 @@
 // src/auth/dto/refresh-token.dto.ts
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class RefreshTokenDto {
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
-  refreshToken: string;
+  refreshToken?: string;
 }


### PR DESCRIPTION
## Summary
- implement DTO for refresh tokens
- use RegisterUserDto, SiweRequestNonceDto, SiweVerifySignatureDto and RefreshTokenDto in `AuthController`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868c27c484c832782b0cba991e0dadf