### PR TITLE
Fix cookie options property and update Prisma stubs

### DIFF
--- a/backend/generated/prisma/index.d.ts
+++ b/backend/generated/prisma/index.d.ts
@@ -8,6 +8,7 @@ export class PrismaClient {
   $connect(): Promise<void>;
   $disconnect(): Promise<void>;
 }
+export const Prisma: any;
 export enum UserRole { FAN = 'FAN', CREATOR = 'CREATOR', ADMIN = 'ADMIN' }
 export enum TipStatus { PENDING = 'PENDING', PROCESSING = 'PROCESSING', COMPLETED = 'COMPLETED', FAILED = 'FAILED', REFUNDED = 'REFUNDED' }
 export enum PayoutStatus { PENDING = 'PENDING', PROCESSING = 'PROCESSING', COMPLETED = 'COMPLETED', FAILED = 'FAILED' }
@@ -16,4 +17,8 @@ export type User = any;
 export type Payout = any;
 export type SocialConnection = any;
 export type OverlaySettings = any;
-export namespace Prisma {}
+export namespace Prisma {
+  export type UserCreateInput = any;
+  export type OverlaySettingsUncheckedUpdateInput = any;
+  export type OverlaySettingsUncheckedCreateInput = any;
+}

--- a/backend/generated/prisma/index.ts
+++ b/backend/generated/prisma/index.ts
@@ -33,4 +33,6 @@ export type Payout = any;
 export const Prisma = {} as any;
 export namespace Prisma {
   export type UserCreateInput = any;
+  export type OverlaySettingsUncheckedUpdateInput = any;
+  export type OverlaySettingsUncheckedCreateInput = any;
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -30,6 +30,7 @@ import { SiweVerifySignatureDto } from './dto/siwe-verify-signature.dto';
 @Controller('auth') // Globalny prefix /api/v1/auth (zdefiniowany w main.ts)
 export class AuthController {
   private readonly logger = new Logger(AuthController.name);
+  private commonCookieOptions: CookieOptions;
 
 
   constructor(

--- a/backend/src/generated/prisma/index.d.ts
+++ b/backend/src/generated/prisma/index.d.ts
@@ -8,6 +8,7 @@ export class PrismaClient {
   $connect(): Promise<void>;
   $disconnect(): Promise<void>;
 }
+export const Prisma: any;
 export enum UserRole { FAN = 'FAN', CREATOR = 'CREATOR', ADMIN = 'ADMIN' }
 export enum TipStatus { PENDING = 'PENDING', PROCESSING = 'PROCESSING', COMPLETED = 'COMPLETED', FAILED = 'FAILED', REFUNDED = 'REFUNDED' }
 export enum PayoutStatus { PENDING = 'PENDING', PROCESSING = 'PROCESSING', COMPLETED = 'COMPLETED', FAILED = 'FAILED' }
@@ -16,4 +17,8 @@ export type User = any;
 export type Payout = any;
 export type SocialConnection = any;
 export type OverlaySettings = any;
-export namespace Prisma {}
+export namespace Prisma {
+  export type UserCreateInput = any;
+  export type OverlaySettingsUncheckedUpdateInput = any;
+  export type OverlaySettingsUncheckedCreateInput = any;
+}


### PR DESCRIPTION
## Summary
- expose `commonCookieOptions` field in `AuthController`
- add exported `Prisma` constant and basic type placeholders for generated stubs

## Testing
- `npm run build` *(fails: Module '@prisma/client' has no exported member 'User')*

------
https://chatgpt.com/codex/tasks/task_e_686beb36a94c83278b69a3e8cf996031