### PR TITLE
Fix invalid JSON in package-lock

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8140,8 +8140,6 @@
         "node": ">=10"
       }
     },
-
-    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",


### PR DESCRIPTION
## Summary
- remove stray closing brace from `frontend/package-lock.json`

## Testing
- `npm run lint` *(fails: Parsing error and unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_686bec1a346c83279cf1934944eb1379