### PR TITLE
Add wallet address modal

### DIFF
--- a/frontend/src/app/[username]/page.tsx
+++ b/frontend/src/app/[username]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, FC, ReactNode } from "react";
+import WalletAddressModal from "../../components/WalletAddressModal";
 import {
   X,
   CreditCard,
@@ -80,10 +81,12 @@ const CreatorProfilePage: FC = () => {
     "profile"
   );
   const [showPaymentModal, setShowPaymentModal] = useState<boolean>(false);
+  const [showAddressModal, setShowAddressModal] = useState<boolean>(false);
   const [showMessageField, setShowMessageField] = useState<boolean>(false); // Re-introduced
   const [isGeneratingMessage, setIsGeneratingMessage] = useState<boolean>(false); // Re-introduced
   const carouselImages = ['/assets/ja1.png', '/assets/ja2.png', '/assets/ja3.png'];
   const [carouselIndex, setCarouselIndex] = useState<number>(0);
+  const walletAddress = "0x1234567890ABCDEF1234567890ABCDEF12345678";
 
 
   const fundingGoal = 1500;
@@ -432,6 +435,15 @@ const CreatorProfilePage: FC = () => {
                 </button>
               </div>
 
+              <div className="mt-2 text-center">
+                <button
+                  onClick={() => setShowAddressModal(true)}
+                  className="inline-flex items-center gap-1 text-sm text-[#9C27B0] hover:text-[#6A1B9A]"
+                >
+                  <Wallet className="w-4 h-4" /> Adres do wpłaty
+                </button>
+              </div>
+
               <div className="mt-6">
                 <p className="text-gray-400 text-center mb-2">
                   Other payment methods
@@ -560,6 +572,14 @@ const CreatorProfilePage: FC = () => {
             </button>
           </div>
         </div>
+      )}
+
+      {showAddressModal && (
+        <WalletAddressModal
+          isOpen={showAddressModal}
+          onClose={() => setShowAddressModal(false)}
+          address={walletAddress}
+        />
       )}
 
       {/* Custom CSS */}

--- a/frontend/src/components/WalletAddressModal.tsx
+++ b/frontend/src/components/WalletAddressModal.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React, { useEffect, useState, Suspense } from 'react';
+import { X, Copy } from 'lucide-react';
+
+const QRCode = React.lazy(() => import('react-qrcode-logo').then(m => ({ default: m.QRCode })));
+
+export interface WalletAddressModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  address: string;
+}
+
+export const WalletAddressModal: React.FC<WalletAddressModalProps> = ({ isOpen, onClose, address }) => {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.body.style.overflow = 'hidden';
+    window.addEventListener('keydown', handleEsc);
+    return () => {
+      document.body.style.overflow = '';
+      window.removeEventListener('keydown', handleEsc);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(address).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {});
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#003737cc] backdrop-blur-sm" onClick={onClose}>
+      <div className="w-full max-w-sm rounded-2xl border border-brand-gold bg-brand-dark p-6 shadow-xl" onClick={e => e.stopPropagation()}>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-bold text-brand-gold">Adres do wpłaty</h2>
+          <button onClick={onClose} aria-label="Zamknij" className="text-brand-gold">
+            <X />
+          </button>
+        </div>
+        <div className="space-y-4 text-center">
+          <div className="flex justify-center">
+            <Suspense fallback={<div className='h-40' />}>
+              <QRCode value={address} size={160} bgColor="#0d2f3f" fgColor="#ffd700"/>
+            </Suspense>
+          </div>
+          <p className="break-words text-sm text-brand-light-text">{address}</p>
+          <button onClick={handleCopy} className="mt-2 flex items-center justify-center gap-2 w-full py-2 rounded-lg bg-brand-gold text-brand-dark font-semibold hover:bg-yellow-400">
+            <Copy className="w-4 h-4" /> {copied ? 'Skopiowano' : 'Kopiuj'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WalletAddressModal;


### PR DESCRIPTION
## Summary
- show QR code and copyable wallet address in new modal
- link to open wallet address modal from creator profile page

## Testing
- `npm run lint` *(fails: Parsing error: ')' expected)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc82932748327940b9940a01a4919