### PR TITLE
Add Circle wallet endpoints

### DIFF
--- a/backend/src/circle/circle.controller.ts
+++ b/backend/src/circle/circle.controller.ts
@@ -1,0 +1,93 @@
+import { Controller, Post, Get, Body, UseGuards, Req, ForbiddenException } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { CircleService } from './circle.service';
+import { Request } from 'express';
+import { ValidatedUser } from '../auth/auth.service';
+import { UserRole } from '@prisma/client';
+
+@Controller('api/v1/circle')
+export class CircleController {
+  constructor(private readonly circleService: CircleService) {}
+
+  @Post('wallet/create')
+  @UseGuards(AuthGuard('jwt'))
+  async createWallet(@Req() req: Request) {
+    const user = req.user as ValidatedUser;
+    const { circleWalletId, mainWalletAddress } = await this.circleService.provisionUserWallet(
+      user.id,
+      user.email,
+      user.role,
+    );
+    return { walletId: circleWalletId, address: mainWalletAddress };
+  }
+
+  @Get('wallet')
+  @UseGuards(AuthGuard('jwt'))
+  async getWallet(@Req() req: Request) {
+    const user = req.user as ValidatedUser;
+    return this.circleService.getWalletForUser(user.id);
+  }
+
+  @Get('wallet/balance')
+  @UseGuards(AuthGuard('jwt'))
+  async getBalance(@Req() req: Request) {
+    const user = req.user as ValidatedUser;
+    return this.circleService.getWalletBalanceForUser(user.id);
+  }
+
+  @Get('wallet/transactions')
+  @UseGuards(AuthGuard('jwt'))
+  async getTransactions(@Req() req: Request) {
+    const user = req.user as ValidatedUser;
+    return this.circleService.getWalletTransactions(user.id);
+  }
+
+  @Post('deposit-hosted')
+  @UseGuards(AuthGuard('jwt'))
+  async createHostedDeposit(@Req() req: Request, @Body() body: { amount: number }) {
+    const user = req.user as ValidatedUser;
+    return this.circleService.createHostedDeposit(user.id, body.amount);
+  }
+
+  @Post('withdraw')
+  @UseGuards(AuthGuard('jwt'))
+  async withdraw(@Req() req: Request, @Body() body: { amount: string; toAddress: string }) {
+    const user = req.user as ValidatedUser;
+    const blockchain = this.circleService.getDefaultBlockchain();
+    const tokenId = this.circleService.getUsdcTokenId();
+    return this.circleService.initiateWithdrawal(
+      user.id,
+      body.toAddress,
+      body.amount,
+      blockchain,
+      tokenId,
+    );
+  }
+
+  @Post('cctp/transfer')
+  @UseGuards(AuthGuard('jwt'))
+  async cctpTransfer(
+    @Req() req: Request,
+    @Body() body: { amount: number; toChain: string; toAddress: string },
+  ) {
+    const user = req.user as ValidatedUser;
+    return this.circleService.initiateCctpTransfer(user.id, body.amount, body.toChain, body.toAddress);
+  }
+
+  @Post('webhook')
+  async webhook(@Body() body: any) {
+    // For now just acknowledge; signature verification would be done inside the service
+    await this.circleService.handleWebhook(body);
+    return { received: true };
+  }
+
+  @Get('admin/circle/wallets')
+  @UseGuards(AuthGuard('jwt'))
+  async listAll(@Req() req: Request) {
+    const user = req.user as ValidatedUser;
+    if (user.role !== UserRole.ADMIN) {
+      throw new ForbiddenException();
+    }
+    return this.circleService.listAllWallets();
+  }
+}

--- a/backend/src/circle/circle.module.ts
+++ b/backend/src/circle/circle.module.ts
@@ -1,10 +1,12 @@
 import { Module, Global } from '@nestjs/common';
 import { CircleService } from './circle.service';
 import { ConfigModule } from '@nestjs/config';
+import { CircleController } from './circle.controller';
 
 @Global()
 @Module({
   imports: [ConfigModule],
+  controllers: [CircleController],
   providers: [CircleService],
   exports: [CircleService],
 })

--- a/backend/src/circle/circle.service.ts
+++ b/backend/src/circle/circle.service.ts
@@ -29,7 +29,7 @@ import {
   Balance,
   TokenInfo,
 } from '@circle-fin/developer-controlled-wallets';
-import { isAxiosError } from 'axios';
+import axios, { isAxiosError } from 'axios';
 import { randomUUID } from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
 import { UserRole } from '@prisma/client';
@@ -309,5 +309,166 @@ export class CircleService implements OnModuleInit {
     } catch (error) {
       this.handleCircleError(error, 'get transaction status');
     }
+  }
+
+  /**
+   * Return wallet information stored locally for given user.
+   */
+  async getWalletForUser(userId: string): Promise<{ walletId: string; address: string; chain: string }> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { circleWalletId: true, mainWalletAddress: true },
+    });
+    if (!user?.circleWalletId || !user?.mainWalletAddress) {
+      throw new NotFoundException('Circle wallet not found for user');
+    }
+    const chain = this.configService.get<string>('DEFAULT_BLOCKCHAIN', 'MATIC-AMOY');
+    return { walletId: user.circleWalletId, address: user.mainWalletAddress, chain };
+  }
+
+  /**
+   * Get wallet balance for a user by querying Circle.
+   */
+  async getWalletBalanceForUser(userId: string): Promise<{ balance: number; currency: string }> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { circleWalletId: true },
+    });
+    if (!user?.circleWalletId) {
+      throw new NotFoundException('User has no Circle wallet');
+    }
+    const balance = await this.getWalletBalance(user.circleWalletId);
+    return { balance, currency: 'USD' };
+  }
+
+  /**
+   * Fetch transactions for the user's Circle wallet.
+   */
+  async getWalletTransactions(userId: string): Promise<any[]> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { circleWalletId: true },
+    });
+    if (!user?.circleWalletId) {
+      throw new NotFoundException('Circle wallet not found');
+    }
+    const apiKey = this.configService.get<string>('CIRCLE_API_KEY');
+    const response = await axios.get(
+      `https://api.circle.com/v1/wallets/${user.circleWalletId}/transactions`,
+      { headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    const transactions = response.data.data || [];
+    return transactions.map(tx => ({
+      id: tx.id,
+      type: tx.type,
+      status: tx.status,
+      amount: tx.amount?.amount,
+      currency: tx.amount?.currency,
+      source: tx.source?.id || null,
+      destination: tx.destination?.address || null,
+      chain: tx.chain,
+      createdAt: tx.createDate,
+    }));
+  }
+
+  /**
+   * Initiate a hosted deposit checkout with Circle Payments API.
+   */
+  async createHostedDeposit(userId: string, amount: number): Promise<{ hostedUrl: string }> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { circleWalletId: true, email: true },
+    });
+    if (!user?.circleWalletId) {
+      throw new NotFoundException('Circle wallet not found');
+    }
+    const apiKey = this.configService.get<string>('CIRCLE_API_KEY');
+    const idempotencyKey = randomUUID();
+    const response = await axios.post(
+      'https://api.circle.com/v1/hosted-checkouts',
+      {
+        idempotencyKey,
+        amount: { amount: amount.toFixed(2), currency: 'USD' },
+        settlementCurrency: 'USD',
+        walletId: user.circleWalletId,
+        customerEmail: user.email,
+        redirectUrl: `${this.configService.get<string>('FRONTEND_URL')}/deposit-success`,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    const url = response.data.data.checkoutUrl;
+    return { hostedUrl: url };
+  }
+
+  /**
+   * Initiate cross chain transfer using Circle CCTP.
+   */
+  async initiateCctpTransfer(
+    userId: string,
+    amount: number,
+    toChain: string,
+    toAddress: string,
+  ): Promise<{ transferId: string }> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { circleWalletId: true },
+    });
+    if (!user?.circleWalletId) {
+      throw new NotFoundException('Wallet not found');
+    }
+    const apiKey = this.configService.get<string>('CIRCLE_API_KEY');
+    const idempotencyKey = randomUUID();
+    const response = await axios.post(
+      'https://api.circle.com/v1/cctp/transfers',
+      {
+        idempotencyKey,
+        source: { walletId: user.circleWalletId, chain: 'POLYGON' },
+        destination: { address: toAddress, chain: toChain },
+        amount: { amount: amount.toFixed(2), currency: 'USD' },
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    return { transferId: response.data.data.id };
+  }
+
+  /**
+   * Handle webhook events from Circle.
+   */
+  async handleWebhook(payload: any): Promise<void> {
+    this.logger.debug(`Received Circle webhook: ${JSON.stringify(payload)}`);
+  }
+
+  /**
+   * List all wallets stored locally (admin use only).
+   */
+  async listAllWallets() {
+    const users = await this.prisma.user.findMany({
+      where: { circleWalletId: { not: null } },
+      select: {
+        id: true,
+        email: true,
+        circleWalletId: true,
+        mainWalletAddress: true,
+      },
+    });
+    return users;
+  }
+
+  getDefaultBlockchain(): Blockchain {
+    return this.configService.get<string>('DEFAULT_BLOCKCHAIN', 'MATIC-AMOY') as Blockchain;
+  }
+
+  getUsdcTokenId(): string {
+    return this.configService.get<string>('USDC_TOKEN_ID', 'USDC');
   }
 }


### PR DESCRIPTION
## Summary
- add CircleController with wallet, balance, transaction, and deposit routes
- extend CircleService with helpers for wallet info, balance, hosted deposits, CCTP transfers and admin wallet listing
- register the controller in CircleModule

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: AuthService etc. not defined)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889190a718c8327ba7a7220820b048f