### PR TITLE
Implement Circle webhook & withdrawal

### DIFF
--- a/backend/prisma/migrations/20250724013000_add_withdrawal_table/migration.sql
+++ b/backend/prisma/migrations/20250724013000_add_withdrawal_table/migration.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "Withdrawal" (
+    "id" TEXT NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+    "userId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "circleTransferId" TEXT NOT NULL,
+    "toAddress" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP,
+    CONSTRAINT "Withdrawal_circleTransferId_key" UNIQUE ("circleTransferId"),
+    CONSTRAINT "Withdrawal_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+CREATE INDEX "Withdrawal_userId_idx" ON "Withdrawal"("userId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -186,3 +186,16 @@ model CircleWallet {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+model Withdrawal {
+  id               String   @id @default(uuid())
+  userId           String
+  amount           Float
+  circleTransferId String   @unique
+  toAddress        String
+  status           String
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  user             User     @relation(fields: [userId], references: [id])
+}

--- a/backend/src/circle/circle.controller.ts
+++ b/backend/src/circle/circle.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Post, Body, Req, UseGuards, Header } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CircleService } from './circle.service';
+import { Request } from 'express';
+
+interface RequestWithUser extends Request {
+  user?: { id: string };
+}
+
+@Controller('circle')
+export class CircleController {
+  constructor(private readonly circleService: CircleService) {}
+
+  @Post('webhook')
+  @Header('Content-Type', 'application/json')
+  async handleWebhook(@Req() req: Request, @Body() body: any) {
+    return this.circleService.handleWebhook(req, body);
+  }
+
+  @Post('withdraw')
+  @UseGuards(JwtAuthGuard)
+  async withdraw(@Req() req: RequestWithUser, @Body() body: { amount: number; toAddress: string }) {
+    const userId = req.user?.id as string;
+    return this.circleService.withdrawUSDC(userId, body.amount, body.toAddress);
+  }
+}

--- a/backend/src/circle/circle.module.ts
+++ b/backend/src/circle/circle.module.ts
@@ -1,10 +1,12 @@
 import { Module, Global } from '@nestjs/common';
 import { CircleService } from './circle.service';
 import { ConfigModule } from '@nestjs/config';
+import { CircleController } from './circle.controller';
 
 @Global()
 @Module({
   imports: [ConfigModule],
+  controllers: [CircleController],
   providers: [CircleService],
   exports: [CircleService],
 })

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -10,6 +10,8 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
   declare tip: any;
   declare user: any;
   declare payout: any;
+  declare withdrawal: any;
+  declare hostedDeposit: any;
   declare socialConnection: any;
   declare overlaySettings: any;
   private readonly logger = new Logger(PrismaService.name);


### PR DESCRIPTION
## Summary
- add CircleController with `webhook` and `withdraw` endpoints
- register controller in CircleModule
- implement `handleWebhook` and `withdrawUSDC` in CircleService
- declare new Prisma models and service properties
- add `Withdrawal` model and migration

## Testing
- `npx @nestjs/cli build`
- `npm test` *(fails: Prisma engine download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688919afb6708327b535e77d21d22151