### PR TITLE
feat: add health check and notification schema

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/terminus": "^11.0.0",
         "@prisma/client": "^6.12.0",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
@@ -3023,6 +3024,76 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/terminus": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-11.0.0.tgz",
+      "integrity": "sha512-c55LOo9YGovmQHtFUMa/vDaxGZ2cglMTZejqgHREaApt/GArTfgYYGwhRXPLq8ZwiQQlLuYB+79e9iA8mlDSLA==",
+      "license": "MIT",
+      "dependencies": {
+        "boxen": "5.1.2",
+        "check-disk-space": "3.4.0"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "*",
+        "@grpc/proto-loader": "*",
+        "@mikro-orm/core": "*",
+        "@mikro-orm/nestjs": "*",
+        "@nestjs/axios": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "@nestjs/microservices": "^10.0.0 || ^11.0.0",
+        "@nestjs/mongoose": "^11.0.0",
+        "@nestjs/sequelize": "^10.0.0 || ^11.0.0",
+        "@nestjs/typeorm": "^10.0.0 || ^11.0.0",
+        "@prisma/client": "*",
+        "mongoose": "*",
+        "reflect-metadata": "0.1.x || 0.2.x",
+        "rxjs": "7.x",
+        "sequelize": "*",
+        "typeorm": "*"
+      },
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "@grpc/proto-loader": {
+          "optional": true
+        },
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/nestjs": {
+          "optional": true
+        },
+        "@nestjs/axios": {
+          "optional": true
+        },
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/mongoose": {
+          "optional": true
+        },
+        "@nestjs/sequelize": {
+          "optional": true
+        },
+        "@nestjs/typeorm": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "mongoose": {
+          "optional": true
+        },
+        "sequelize": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.5",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.5.tgz",
@@ -5243,6 +5314,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -5716,6 +5796,90 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -5977,7 +6141,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -6016,6 +6179,15 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/check-disk-space": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
+      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.12",
@@ -6144,6 +6316,18 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -8472,7 +8656,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13825,7 +14008,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15196,6 +15378,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/with": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/terminus": "^11.0.0",
     "@prisma/client": "^6.12.0",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -71,6 +71,7 @@ model User {
   tipsReceived      Tip[]              @relation("TipsReceivedByCreator")
 
   payouts         Payout[]
+  notifications   Notification[]
   overlaySettings OverlaySettings?
 
   circleWallet CircleWallet?
@@ -198,4 +199,16 @@ model Withdrawal {
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 
+}
+
+model Notification {
+  id        String   @id @default(uuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  type      String?
+  message   String
+  read      Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  @@index([userId])
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -23,6 +23,7 @@ import { NotificationModule } from './notification/notification.module';
 
 // Newly added FanModule
 import { FanModule } from './fan/fan.module';
+import { HealthModule } from './health/health.module';
 
 @Module({
   imports: [
@@ -65,6 +66,7 @@ import { FanModule } from './fan/fan.module';
     NotificationModule,
     // Import the fan module to enable fan endpoints
     FanModule,
+    HealthModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get } from '@nestjs/common';
+import {
+  HealthCheck,
+  HealthCheckService,
+  HttpHealthIndicator,
+  PrismaHealthIndicator,
+  DiskHealthIndicator,
+  MemoryHealthIndicator,
+} from '@nestjs/terminus';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Controller('health')
+export class HealthController {
+  constructor(
+    private health: HealthCheckService,
+    private http: HttpHealthIndicator,
+    private prismaIndicator: PrismaHealthIndicator,
+    private prisma: PrismaService,
+    private disk: DiskHealthIndicator,
+    private memory: MemoryHealthIndicator,
+  ) {}
+
+  @Get()
+  @HealthCheck()
+  check() {
+    return this.health.check([
+      () => this.http.pingCheck('self', 'http://localhost:3000'),
+      () => this.prismaIndicator.pingCheck('database', this.prisma),
+      () =>
+        this.disk.checkStorage('disk', { path: '/', thresholdPercent: 0.9 }),
+      () => this.memory.checkRSS('memory_rss', 150 * 1024 * 1024),
+    ]);
+  }
+}

--- a/backend/src/health/health.module.ts
+++ b/backend/src/health/health.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TerminusModule } from '@nestjs/terminus';
+import { PrismaModule } from '../prisma/prisma.module';
+import { HealthController } from './health.controller';
+
+@Module({
+  imports: [TerminusModule, PrismaModule],
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/backend/src/notification/notification.controller.ts
+++ b/backend/src/notification/notification.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, UseGuards, Request } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { NotificationService } from './notification.service';
 
@@ -11,5 +19,12 @@ export class NotificationController {
   async getNotifications(@Request() req) {
     const userId: string = req.user?.id;
     return this.notificationService.getUserNotifications(userId);
+  }
+
+  @Post('mark-as-read')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async markAsRead(@Request() req) {
+    const userId: string = req.user?.id;
+    await this.notificationService.markAllAsRead(userId);
   }
 }

--- a/backend/src/payouts/payouts.controller.ts
+++ b/backend/src/payouts/payouts.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Post, Body, UseGuards, Req, HttpCode, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Get,
+  Param,
+  Body,
+  UseGuards,
+  Req,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { PayoutsService } from './payouts.service';
 import { CreatePayoutDto } from './dto/create-payout.dto';
@@ -13,8 +23,29 @@ export class PayoutsController {
   @Post('payout')
   @UseGuards(AuthGuard('jwt'))
   @HttpCode(HttpStatus.CREATED)
-  createPayout(@Req() req: Request, @Body() dto: CreatePayoutDto): Promise<Payout> {
+  createPayout(
+    @Req() req: Request,
+    @Body() dto: CreatePayoutDto,
+  ): Promise<Payout> {
     const user = req.user as ValidatedUser;
-    return this.payoutsService.createPayout(user.id, dto.amount, dto.destinationAddress);
+    return this.payoutsService.createPayout(
+      user.id,
+      dto.amount,
+      dto.destinationAddress,
+    );
+  }
+
+  @Get('payouts')
+  @UseGuards(AuthGuard('jwt'))
+  getPayouts(@Req() req: Request): Promise<Payout[]> {
+    const user = req.user as ValidatedUser;
+    return this.payoutsService.getPayoutsForCreator(user.id);
+  }
+
+  @Get('payouts/:id')
+  @UseGuards(AuthGuard('jwt'))
+  getPayout(@Req() req: Request, @Param('id') id: string): Promise<Payout> {
+    const user = req.user as ValidatedUser;
+    return this.payoutsService.getPayoutForCreator(user.id, id);
   }
 }


### PR DESCRIPTION
## Summary
- add Notification model and relation to User
- expose mark-as-read endpoint for notifications
- implement Terminus-based health check endpoint
- allow creators to list and fetch their payouts

## Testing
- `npm test` *(fails: Cannot find name 'AuthService', etc.)*
- `npm run lint` *(fails: many @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688da326c6048327a55cf2ba7b219b88