### PR TITLE
feat: notify creators of new tips

### DIFF
--- a/backend/src/tips/tips.module.ts
+++ b/backend/src/tips/tips.module.ts
@@ -2,9 +2,10 @@ import { Module, forwardRef } from '@nestjs/common';
 import { TipsService } from './tips.service';
 import { TipsController } from './tips.controller';
 import { UsersModule } from '../users/users.module';
+import { NotificationModule } from '../notification/notification.module';
 
 @Module({
-  imports: [forwardRef(() => UsersModule)],
+  imports: [forwardRef(() => UsersModule), NotificationModule],
   controllers: [TipsController],
   providers: [TipsService],
   exports: [TipsService],

--- a/backend/src/tips/tips.service.spec.ts
+++ b/backend/src/tips/tips.service.spec.ts
@@ -4,8 +4,10 @@ import { PrismaService } from '../prisma/prisma.service';
 import { UsersService } from '../users/users.service';
 import { CircleService } from '../circle/circle.service';
 import { ConfigService } from '@nestjs/config';
+import { NotificationService } from '../notification/notification.service';
 
 jest.mock('@prisma/client', () => ({
+  PrismaClient: class {},
   TipStatus: { PENDING: 'PENDING', COMPLETED: 'COMPLETED', FAILED: 'FAILED' },
   UserRole: { CREATOR: 'CREATOR', FAN: 'FAN' },
 }));
@@ -19,6 +21,7 @@ describe('TipsService', () => {
   let usersService: any;
   let circleService: any;
   let config: any;
+  let notificationService: any;
 
   beforeEach(async () => {
     prisma = {
@@ -36,6 +39,7 @@ describe('TipsService', () => {
         return def;
       }),
     };
+    notificationService = { create: jest.fn() };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -44,6 +48,7 @@ describe('TipsService', () => {
         { provide: UsersService, useValue: usersService },
         { provide: CircleService, useValue: circleService },
         { provide: ConfigService, useValue: config },
+        { provide: NotificationService, useValue: notificationService },
       ],
     }).compile();
 
@@ -79,6 +84,9 @@ describe('TipsService', () => {
           circleTransferId: 'tx',
         }),
       }),
+    );
+    expect(notificationService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'creator' }),
     );
     expect(result.status).toBe(TipStatus.COMPLETED);
   });
@@ -127,6 +135,9 @@ describe('TipsService', () => {
           paymentGatewayChargeId: expect.any(String),
         }),
       }),
+    );
+    expect(notificationService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'creator' }),
     );
     expect(result.status).toBe(TipStatus.COMPLETED);
   });


### PR DESCRIPTION
## Summary
- notify creators when a tip is processed
- wire tips module to notification module
- test that tip processing emits notifications

## Testing
- `npm test` *(fails: AuthController should be defined)*
- `npx jest src/tips/tips.service.spec.ts`
- `npm run lint` *(fails: Parsing error: app.controller.spec.ts was not found)*

------
https://chatgpt.com/codex/tasks/task_e_688da3b22a9c8327991fe200f6a91539