### PR TITLE
feat: add public profile API

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -10,6 +10,8 @@ import {
   HttpStatus,
   UnauthorizedException,
   Logger,
+  Param,
+  NotFoundException,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { UsersService } from './users.service';
@@ -24,6 +26,17 @@ export class UsersController {
   private readonly logger = new Logger(UsersController.name);
 
   constructor(private usersService: UsersService) {}
+
+  @Get('profile/:username')
+  @HttpCode(HttpStatus.OK)
+  async getPublicProfile(@Param('username') username: string): Promise<any> {
+    const profile =
+      await this.usersService.findPublicProfileByUsername(username);
+    if (!profile) {
+      throw new NotFoundException('User not found');
+    }
+    return profile;
+  }
 
   @Get('username-check')
   @HttpCode(HttpStatus.OK)

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -138,7 +138,12 @@ export class UsersService {
         `Failed to create user (Email: ${userEmail || 'N/A'}): ${(error as Error).message}`,
         (error as Error).stack,
       );
-      if (error instanceof Error && 'code' in error && typeof error.code === 'string' && error.code === 'P2002') {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        typeof error.code === 'string' &&
+        error.code === 'P2002'
+      ) {
         const target = (error as any).meta?.target?.join(', ');
         this.logger.warn(`Prisma unique constraint violation on: ${target}`);
         throw new ConflictException(
@@ -199,7 +204,11 @@ export class UsersService {
         `Failed to update user ID [${id}]: ${(error as Error).message}`,
         (error as Error).stack,
       );
-      if (error instanceof Error && 'code' in error && typeof error.code === 'string') {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        typeof error.code === 'string'
+      ) {
         if (error.code === 'P2025') {
           this.logger.warn(`Update failed: User ID [${id}] not found.`);
           throw new NotFoundException(
@@ -353,7 +362,12 @@ export class UsersService {
         `Failed to add social connection for user ID [${userId}]: ${(error as Error).message}`,
         (error as Error).stack,
       );
-      if (error instanceof Error && 'code' in error && typeof error.code === 'string' && error.code === 'P2002') {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        typeof error.code === 'string' &&
+        error.code === 'P2002'
+      ) {
         throw new ConflictException(
           'To połączenie społeczne już istnieje lub wystąpił inny konflikt unikalności.',
         );
@@ -367,6 +381,47 @@ export class UsersService {
   async findByUsername(username: string): Promise<User | null> {
     return this.prisma.user.findUnique({
       where: { username: username.toLowerCase() },
+    });
+  }
+
+  /**
+   * Retrieves a public profile for the given username. Only non-sensitive
+   * fields that should be exposed publicly are selected.
+   */
+  async findPublicProfileByUsername(username: string): Promise<{
+    username: string | null;
+    displayName: string;
+    avatarUrl: string | null;
+    mainWalletAddress: string | null;
+    profile: {
+      bio: string | null;
+      bannerUrl: string | null;
+      customTipJarUrlSuffix: string | null;
+      acceptsTips: boolean;
+      websiteUrl: string | null;
+      twitterUrl: string | null;
+      youtubeUrl: string | null;
+    } | null;
+  } | null> {
+    return this.prisma.user.findUnique({
+      where: { username: username.toLowerCase() },
+      select: {
+        username: true,
+        displayName: true,
+        avatarUrl: true,
+        mainWalletAddress: true,
+        profile: {
+          select: {
+            bio: true,
+            bannerUrl: true,
+            customTipJarUrlSuffix: true,
+            acceptsTips: true,
+            websiteUrl: true,
+            twitterUrl: true,
+            youtubeUrl: true,
+          },
+        },
+      },
     });
   }
 

--- a/frontend/src/app/creator/profile/[username]/page.tsx
+++ b/frontend/src/app/creator/profile/[username]/page.tsx
@@ -1,6 +1,6 @@
-"use client"
-import { notFound } from 'next/navigation';
-import Image from 'next/image';
+"use client";
+import { notFound } from "next/navigation";
+import Image from "next/image";
 
 interface CreatorProfileProps {
   params: { username: string };
@@ -17,26 +17,30 @@ interface CreatorProfileProps {
  * currently mocked – integrate with your backend API or database as needed.
  */
 async function fetchCreator(username: string) {
-  // TODO: replace with API call to fetch profile by username
-  // Example structure returned for demonstration
-  return {
-    username,
-    displayName: 'Jane Doe',
-    tagline: 'Video creator and illustrator',
-    bio: 'I’m a video creator and illustrator sharing tutorials, behind‑the‑scenes content and creative inspiration.',
-    avatarUrl: '/placeholder_light_gray_block.png',
-    bannerUrl: '/placeholder_light_gray_block.png',
-    goal: 1000,
-    raised: 350,
-    quickAmounts: [1, 5, 10, 25],
-    accentColor: '#1EB589',
-    supporters: [
-      { name: 'Aaron', amount: 20, message: '', date: '3h ago' },
-      { name: 'Anonymous', amount: 10, message: '', date: '1 day ago' },
-      { name: 'Emma', amount: 50, message: 'You’re amazing!', date: '2 days ago' },
-    ],
-    donationAddress: '0x1234...abcd',
-  };
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/users/profile/${username}`,
+      { cache: "no-store" },
+    );
+    if (!res.ok) return null;
+    const user = await res.json();
+    return {
+      username: user.username,
+      displayName: user.displayName,
+      tagline: "",
+      bio: user.profile?.bio ?? "",
+      avatarUrl: user.avatarUrl || "/placeholder_light_gray_block.png",
+      bannerUrl: user.profile?.bannerUrl || "/placeholder_light_gray_block.png",
+      goal: 0,
+      raised: 0,
+      quickAmounts: [1, 5, 10, 25],
+      accentColor: "#1EB589",
+      supporters: [],
+      donationAddress: user.mainWalletAddress || "",
+    };
+  } catch {
+    return null;
+  }
 }
 
 export default async function CreatorProfile({ params }: CreatorProfileProps) {
@@ -48,11 +52,21 @@ export default async function CreatorProfile({ params }: CreatorProfileProps) {
       <div className="relative rounded-lg overflow-hidden shadow-md">
         <div className="h-48 bg-gray-200 relative">
           {data.bannerUrl && (
-            <Image src={data.bannerUrl} alt="Banner" fill style={{ objectFit: 'cover' }} />
+            <Image
+              src={data.bannerUrl}
+              alt="Banner"
+              fill
+              style={{ objectFit: "cover" }}
+            />
           )}
         </div>
         <div className="absolute -bottom-12 left-6 rounded-full border-4 border-white w-24 h-24 overflow-hidden">
-          <Image src={data.avatarUrl} alt="Avatar" fill style={{ objectFit: 'cover' }} />
+          <Image
+            src={data.avatarUrl}
+            alt="Avatar"
+            fill
+            style={{ objectFit: "cover" }}
+          />
         </div>
       </div>
       <div className="mt-16 px-6">
@@ -60,26 +74,29 @@ export default async function CreatorProfile({ params }: CreatorProfileProps) {
         <p className="text-teal-600 mt-1">@{data.username}</p>
         <p className="mt-4 text-gray-700">{data.bio}</p>
         {/* Social links placeholder – update when available */}
-        <div className="flex space-x-4 mt-4">
-          {/* Icons would go here */}
-        </div>
+        <div className="flex space-x-4 mt-4">{/* Icons would go here */}</div>
       </div>
       {/* Fundraising stats */}
       <div className="px-6 mt-8 flex items-center space-x-4">
-          <div className="flex items-center space-x-2">
-            <span className="text-xl font-medium">${data.raised.toFixed(0)}</span>
-            <span className="text-gray-500">raised</span>
-          </div>
-          <div className="h-2 flex-1 bg-gray-200 rounded">
-            <div
-              className="h-full rounded"
-              style={{ width: `${(data.raised / data.goal) * 100}%`, backgroundColor: data.accentColor }}
-            />
-          </div>
-          <div className="flex items-center space-x-2">
-            <span className="text-xl font-medium">{((data.raised / data.goal) * 100).toFixed(0)}%</span>
-            <span className="text-gray-500">of ${data.goal}</span>
-          </div>
+        <div className="flex items-center space-x-2">
+          <span className="text-xl font-medium">${data.raised.toFixed(0)}</span>
+          <span className="text-gray-500">raised</span>
+        </div>
+        <div className="h-2 flex-1 bg-gray-200 rounded">
+          <div
+            className="h-full rounded"
+            style={{
+              width: `${(data.raised / data.goal) * 100}%`,
+              backgroundColor: data.accentColor,
+            }}
+          />
+        </div>
+        <div className="flex items-center space-x-2">
+          <span className="text-xl font-medium">
+            {((data.raised / data.goal) * 100).toFixed(0)}%
+          </span>
+          <span className="text-gray-500">of ${data.goal}</span>
+        </div>
       </div>
       {/* Tip panel */}
       <div className="px-6 mt-10 grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -110,7 +127,9 @@ export default async function CreatorProfile({ params }: CreatorProfileProps) {
       {/* Donation address / QR */}
       <div className="px-6 mt-10">
         <h2 className="font-semibold mb-2">Donation address</h2>
-        <p className="font-mono text-gray-700 break-all">{data.donationAddress}</p>
+        <p className="font-mono text-gray-700 break-all">
+          {data.donationAddress}
+        </p>
         {/* A QR code could be generated and rendered here via a library */}
       </div>
       {/* Recent supporters */}


### PR DESCRIPTION
## Summary
- expose `GET /users/profile/:username` for public profile access
- fetch creator profile data from backend on profile page

## Testing
- `npm test` (backend) *(fails: Cannot find name 'AuthService')*
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` (frontend) *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688da4472cac832797afec4548a7b2db