### PR TITLE
Add Google font configuration

### DIFF
--- a/frontend/src/app/fonts.ts
+++ b/frontend/src/app/fonts.ts
@@ -1,0 +1,29 @@
+import { Inter, IBM_Plex_Sans, Mukta, Playfair_Display } from 'next/font/google'
+
+export const mukta = Mukta({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  display: 'swap',
+  variable: '--font-mukta',
+})
+
+export const inter = Inter({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  display: 'swap',
+  variable: '--font-inter',
+})
+
+export const ibm = IBM_Plex_Sans({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  display: 'swap',
+  variable: '--font-ibm',
+})
+
+export const playfair = Playfair_Display({
+  subsets: ['latin'],
+  weight: ['400', '500', '700'],
+  display: 'swap',
+  variable: '--font-playfair',
+})

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,15 +1,8 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
-import { Montserrat } from 'next/font/google';
-import { cn } from '@/lib/utils';
+import { mukta, inter, ibm, playfair } from './fonts';
 import { Providers } from './providers'; // Importujemy nasz wrapper dla wagmi
-
-// Konfiguracja czcionki Montserrat z next/font
-const montserrat = Montserrat({
-  subsets: ['latin'],
-  variable: '--font-sans', // Definiujemy zmienną CSS dla naszej czcionki
-});
 
 export const metadata: Metadata = {
   title: {
@@ -21,13 +14,12 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body
-        className={cn(
-          "min-h-screen bg-[#003737] font-sans text-white antialiased",
-          montserrat.variable // Aplikujemy zmienną z czcionką do całego body
-        )}
-      >
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${mukta.variable} ${inter.variable} ${ibm.variable} ${playfair.variable}`}
+    >
+      <body className="min-h-screen bg-[#003737] font-sans text-white antialiased">
         {/*
           Opakowujemy całą aplikację w Providers.
           To sprawia, że hooki z wagmi (do obsługi portfela)

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -14,7 +14,10 @@ const config: Config = {
         'brand-light-text': '#b0c4de'
       },
       fontFamily: {
-        sans: ['var(--font-sans)'],
+        sans: ['var(--font-mukta)', 'sans-serif'],
+        ui: ['var(--font-inter)', 'sans-serif'],
+        mono: ['var(--font-ibm)', 'monospace'],
+        accent: ['var(--font-playfair)', 'serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- add Next.js Google font declarations for Mukta, Inter, IBM Plex Sans, and Playfair Display
- configure Tailwind to expose new font families
- apply fonts to the root layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Parsing error in login page and other lint errors)
- `npm run build` (fails: Failed to fetch Google Fonts and existing webpack errors)


------
https://chatgpt.com/codex/tasks/task_e_68904e9b95dc8327802acc1a81a1d9ca