### PR TITLE
feat: add reusable button components

### DIFF
--- a/frontend/src/components/buttons/CreatorButton.tsx
+++ b/frontend/src/components/buttons/CreatorButton.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+export const CreatorButton = () => {
+  return (
+    <Link
+      href="/signup"
+      className="px-6 py-3 rounded-full bg-gradient-to-r from-orange-500 to-yellow-400 text-black font-semibold shadow-md hover:scale-[1.03] transition-transform"
+    >
+      Begin as a creator
+    </Link>
+  );
+};
+

--- a/frontend/src/components/buttons/ExploreButton.tsx
+++ b/frontend/src/components/buttons/ExploreButton.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+export const ExploreButton = () => {
+  return (
+    <Link
+      href="/explore"
+      className="px-6 py-3 rounded-full bg-gradient-to-r from-purple-600 to-fuchsia-600 text-white font-semibold shadow-md hover:scale-[1.03] transition-transform"
+    >
+      Explore as fun
+    </Link>
+  );
+};
+

--- a/frontend/src/components/buttons/IconButton.tsx
+++ b/frontend/src/components/buttons/IconButton.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+interface IconButtonProps {
+  href?: string;
+  children: ReactNode;
+}
+
+export const IconButton = ({ href = "#", children }: IconButtonProps) => {
+  return (
+    <Link
+      href={href}
+      className="p-3 rounded-full border border-[#063250] text-[#063250] hover:bg-[#063250]/10 hover:shadow-[0_0_10px_#063250] transition-all duration-300"
+    >
+      {children}
+    </Link>
+  );
+};
+

--- a/frontend/src/components/buttons/LoginButton.tsx
+++ b/frontend/src/components/buttons/LoginButton.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+
+export const LoginButton = () => {
+  return (
+    <Link
+      href="/login"
+      className="px-6 py-3 rounded-full border border-[#063250] text-[#063250] font-semibold hover:bg-[#063250]/10 hover:shadow-[0_0_10px_#063250] transition-all duration-300"
+    >
+      Login
+    </Link>
+  );
+};
+

--- a/frontend/src/components/buttons/SolidButton.tsx
+++ b/frontend/src/components/buttons/SolidButton.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+interface SolidButtonProps {
+  href?: string;
+  children: ReactNode;
+}
+
+export const SolidButton = ({ href = "#", children }: SolidButtonProps) => {
+  return (
+    <Link
+      href={href}
+      className="px-6 py-3 rounded-full bg-[#063250] text-white font-semibold shadow-md hover:scale-[1.03] transition-transform"
+    >
+      {children}
+    </Link>
+  );
+};
+

--- a/frontend/src/components/buttons/index.ts
+++ b/frontend/src/components/buttons/index.ts
@@ -1,0 +1,6 @@
+export { CreatorButton } from "./CreatorButton";
+export { ExploreButton } from "./ExploreButton";
+export { LoginButton } from "./LoginButton";
+export { IconButton } from "./IconButton";
+export { SolidButton } from "./SolidButton";
+


### PR DESCRIPTION
## Summary
- add CreatorButton and ExploreButton for onboarding
- add LoginButton, IconButton and SolidButton for layout
- export all new buttons from a barrel file

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error and other warnings in existing code)*
- `npx next lint --file src/components/buttons/CreatorButton.tsx --file src/components/buttons/ExploreButton.tsx --file src/components/buttons/LoginButton.tsx --file src/components/buttons/IconButton.tsx --file src/components/buttons/SolidButton.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6892319193608327b88c24bc2aaea22d