### PR TITLE
Add SecondaryButton component and integrate into Hero

### DIFF
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -1,11 +1,14 @@
+import { SecondaryButton } from './SecondaryButton';
+
 const Hero = () => (
   <section className="h-screen bg-tipjar-main flex flex-col justify-center items-center text-center px-4">
     <h1 className="text-5xl font-title text-tipjar-gold mb-4 animate-fadeIn">TipIT</h1>
     <p className="text-xl max-w-xl text-whiteish mb-6">Start building your page with TipJar+ and accept USDC tips in 60 seconds.</p>
     <div className="flex gap-4">
       <button className="bg-tipjar-gold text-tipjar-dark px-6 py-3 rounded-lg font-semibold hover:scale-105 transition">Sign Up as Creator</button>
-      <button className="border border-tipjar-gold text-tipjar-gold px-6 py-3 rounded-lg hover:bg-tipjar-gold hover:text-tipjar-dark transition">Discover Creators</button>
+      <SecondaryButton />
     </div>
   </section>
-)
+);
+
 export default Hero;

--- a/frontend/src/components/SecondaryButton.tsx
+++ b/frontend/src/components/SecondaryButton.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export const SecondaryButton = () => {
+  return (
+    <Link
+      href="/explore"
+      className="px-6 py-3 rounded-full bg-gradient-to-r from-purple-600 to-fuchsia-600 text-white font-semibold shadow-md hover:scale-[1.03] transition-transform"
+    >
+      Explore as fun
+    </Link>
+  );
+};
+


### PR DESCRIPTION
## Summary
- add gradient SecondaryButton linking to /explore
- use SecondaryButton in Hero component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing errors and unused variables in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68922dc28bc08327b00748a7d845a97f