### PR TITLE
feat: add global gradient background

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -138,3 +138,9 @@
   font-style: normal;
   font-display: swap;
 }
+
+body {
+  background: #003737;
+  background: -webkit-linear-gradient(133deg, #003737 0%, #006565 50%, #002828 100%);
+  background: linear-gradient(133deg, #003737 0%, #006565 50%, #002828 100%);
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en" suppressHydrationWarning>
       <body
         className={cn(
-          "min-h-screen bg-[#003737] font-sans text-white antialiased",
+          "min-h-screen font-sans text-white antialiased",
           montserrat.variable // Aplikujemy zmienną z czcionką do całego body
         )}
       >


### PR DESCRIPTION
## Summary
- apply gradient styling to body for consistent look
- clean up root layout to rely on global background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error: Declaration or statement expected)*
- `npm run build` *(fails: Failed to fetch `Montserrat` from Google Fonts and other syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_6892252bfbfc83279bf6110fbae7d63a