### PR TITLE
feat: add gradient background to layout

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -14,7 +14,8 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-
+    <html lang="en">
+      <body className="min-h-screen bg-gradient-to-b from-[#551655] to-[#471347]">
         {/*
           Opakowujemy całą aplikację w Providers.
           To sprawia, że hooki z wagmi (do obsługi portfela)


### PR DESCRIPTION
## Summary
- add gradient background to RootLayout body

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Parsing error)


------
https://chatgpt.com/codex/tasks/task_e_6892c562d5288327aebdd7bc30d1c71d