### PR TITLE
fix: resolve terminus prisma check

### DIFF
--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -25,7 +25,11 @@ export class HealthController {
   check() {
     return this.health.check([
       () => this.http.pingCheck('self', 'http://localhost:3000'),
-      () => this.prismaIndicator.pingCheck('database', this.prisma),
+      () =>
+        this.prismaIndicator.pingCheck(
+          'database',
+          this.prisma as unknown as any,
+        ),
       () =>
         this.disk.checkStorage('disk', { path: '/', thresholdPercent: 0.9 }),
       () => this.memory.checkRSS('memory_rss', 150 * 1024 * 1024),


### PR DESCRIPTION
## Summary
- cast Prisma service as any when running Terminus database health check

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find name 'AuthService')*
- `npm run lint` *(fails: 458 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68952932410483279f1777f6c49237d0