### PR TITLE
Fix missing terminus dependency

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,7 @@
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
-        "@nestjs/terminus": "^11.0.0",
+        "@nestjs/terminus": "11.0.0",
         "@prisma/client": "^6.12.0",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,7 +29,7 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
-    "@nestjs/terminus": "^11.0.0",
+    "@nestjs/terminus": "11.0.0",
     "@prisma/client": "^6.12.0",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",


### PR DESCRIPTION
## Summary
- pin `@nestjs/terminus` so the health module builds reliably

## Testing
- `npm run build`
- `npm test` *(fails: this.configService.get is not a function; Cannot find name 'AuthService')*

------
https://chatgpt.com/codex/tasks/task_e_68952d89164883278ff06719bae1acd3