### PR TITLE
feat: add landing and support pages

### DIFF
--- a/frontend/src/app/creator/[handle]/page.tsx
+++ b/frontend/src/app/creator/[handle]/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+import { useState } from "react";
+import { TipModal } from "@/components/TipModal";
+import { FanWall } from "@/components/FanWall";
+import { Button } from "@/components/Button";
+
+export default function CreatorProfilePage({ params }: { params: { handle: string } }) {
+  const [open, setOpen] = useState(false);
+  // In real app, fetch profile by handle
+  const creator = {
+    handle: params.handle,
+    name: params.handle.replace(/(^.|_.)/g, (m) => m.toUpperCase()),
+    avatarUrl: "https://i.pravatar.cc/150?img=5",
+    bio: "Short bio about the creator.",
+  };
+  const fans = Array.from({ length: 14 }).map((_, i) => ({
+    id: String(i),
+    avatarUrl: `https://i.pravatar.cc/100?img=${(i % 70) + 1}`,
+    amount: i % 3 ? 3 : 5,
+    timeAgo: `${i + 1}h`,
+  }));
+  return (
+    <div className="grid gap-8 md:grid-cols-[2fr_1fr]">
+      {/* Left column */}
+      <div>
+        <div className="flex items-center gap-4">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={creator.avatarUrl}
+            alt={creator.name}
+            className="h-20 w-20 rounded-full object-cover"
+          />
+          <div>
+            <h1 className="text-2xl font-bold">
+              {creator.name}{" "}
+              <span className="align-middle text-base text-[#FFD700]">✔</span>
+            </h1>
+            <p className="text-white/70">@{creator.handle}</p>
+          </div>
+        </div>
+        <p className="mt-4 text-white/80">{creator.bio}</p>
+        <div className="mt-6 flex gap-3">
+          <Button onClick={() => setOpen(true)} variant="gold">
+            Wesprzyj / Tip
+          </Button>
+          <Button variant="outline">Subscribe NFT</Button>
+        </div>
+        <section className="mt-10">
+          <h2 className="text-xl font-bold">Latest tips</h2>
+          <div className="mt-3 space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div
+                key={i}
+                className="rounded-2xl border border-white/10 bg-[#140a2a] p-3"
+              >
+                <div className="flex justify-between text-sm">
+                  <span>Fan {i + 1}</span>
+                  <span className="text-white/70">{i % 2 ? 3 : 5} USDC</span>
+                </div>
+                <p className="mt-1 text-sm text-white/80">
+                  Great work! Keep it up.
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+      {/* Right column */}
+      <aside className="space-y-6">
+        <div className="rounded-2xl border border-white/10 bg-[#140a2a] p-4">
+          <h3 className="font-semibold">Recent supporters</h3>
+          <div className="mt-3">
+            <FanWall fans={fans} />
+          </div>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-[#140a2a] p-4">
+          <h3 className="font-semibold">Socials</h3>
+          <ul className="mt-2 space-y-1 text-sm text-white/80">
+            <li>X: @{creator.handle}</li>
+            <li>Youtube: /{creator.handle}</li>
+            <li>Twitch: /{creator.handle}</li>
+          </ul>
+        </div>
+      </aside>
+      <TipModal
+        open={open}
+        onClose={() => setOpen(false)}
+        creator={{ name: creator.name, handle: creator.handle }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/creator/dashboard/page.tsx
+++ b/frontend/src/app/creator/dashboard/page.tsx
@@ -1,29 +1,29 @@
-// app/creator/dashboard/page.tsx
-import Link from 'next/link';
-
 export default function CreatorDashboardPage() {
   return (
-    <main className="min-h-screen bg-white" style={{ fontFamily: 'Montserrat, sans-serif' }}>
-      <header className="bg-[#003737] text-white p-4 flex justify-between items-center">
-        <h1 className="text-2xl">Creator Dashboard</h1>
-        <nav>
-          <Link href="/creator/dashboard" className="px-3 text-[#FFD700]">Dashboard</Link>
-          <Link href="/creator/withdrawals" className="px-3 hover:text-[#FFD700]">Withdrawals</Link>
-          <Link href="/creator/settings" className="px-3 hover:text-[#FFD700]">Settings</Link>
-          <Link href="/" className="px-3 hover:text-[#FFD700]">Logout</Link>
-        </nav>
-      </header>
-      <section className="p-8">
-        <h2 className="text-xl mb-2">Summary Statistics</h2>
-        <p className="mb-4">Total Tips Received: <span className="font-bold">$123.45</span></p>
-        <p className="mb-6">Current Balance: <span className="font-bold">$67.89</span></p>
-        <h2 className="text-xl mb-2">Recent Tips</h2>
-        <ul className="list-disc pl-5 text-gray-700">
-          <li>Carol tipped $10 – "Love your work!"</li>
-          <li>Dave tipped $5 – "Great content!"</li>
-          <li>Anonymous tipped $2</li>
-        </ul>
-      </section>
-    </main>
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Creator Dashboard</h1>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {["Tips today", "Total supporters", "USDC balance", "Payouts"].map((t, i) => (
+          <div key={t} className="rounded-2xl border border-white/10 bg-[#140a2a] p-4">
+            <div className="text-sm text-white/60">{t}</div>
+            <div className="mt-2 text-2xl font-bold">{["23", "4,120", "1,053", "2"][i]}</div>
+          </div>
+        ))}
+      </div>
+      <div className="rounded-2xl border border-white/10 bg-[#140a2a] p-4">
+        <h2 className="font-semibold">Recent tips</h2>
+        <div className="mt-3 space-y-2 text-sm">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex justify-between border-b border-white/10 py-2 last:border-0"
+            >
+              <span>Fan {i + 1}</span>
+              <span className="text-white/70">{i % 2 ? 3 : 5} USDC</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,14 @@
+"use client";
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <html>
+      <body className="grid min-h-screen place-items-center bg-[#1a1034] p-6 text-white">
+        <div className="max-w-md text-center">
+          <h2 className="text-3xl font-extrabold">Well, that escalated quickly (500).</h2>
+          <p className="mt-2 text-white/80">{error.message || "Something went wrong."}</p>
+          <button onClick={() => reset()} className="mt-4 rounded-xl bg-[#6B46C1] px-4 py-2 font-semibold">Try again</button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/explore/page.tsx
+++ b/frontend/src/app/explore/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useMemo, useState } from "react";
+import { CreatorCard } from "@/components/CreatorCard";
+
+const MOCK = Array.from({ length: 24 }).map((_, i) => ({
+  handle: `creator${i + 1}`,
+  name: `Creator ${i + 1}`,
+  bio: "Making awesome stuff on the internet.",
+  avatarUrl: `https://i.pravatar.cc/150?img=${(i % 70) + 1}`,
+}));
+
+export default function ExplorePage() {
+  const [q, setQ] = useState("");
+  const [top] = useState(MOCK.slice(0, 8));
+  const filtered = useMemo(
+    () =>
+      MOCK.filter((c) =>
+        (c.name + c.handle + c.bio).toLowerCase().includes(q.toLowerCase())
+      ),
+    [q]
+  );
+  return (
+    <div className="space-y-8">
+      <div className="rounded-2xl border border-white/10 bg-[#140a2a] p-4">
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search creators…"
+          className="w-full rounded-xl border border-white/20 bg-transparent px-3 py-2 outline-none focus:border-white/40"
+        />
+      </div>
+      <section>
+        <h2 className="mb-3 text-xl font-bold">Top creators</h2>
+        <div className="flex snap-x gap-4 overflow-x-auto pb-2">
+          {top.map((c) => (
+            <div key={c.handle} className="snap-start w-56 shrink-0">
+              <CreatorCard creator={c} />
+            </div>
+          ))}
+        </div>
+      </section>
+      <section>
+        <h2 className="mb-3 text-xl font-bold">All creators</h2>
+        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {filtered.map((c) => (
+            <CreatorCard key={c.handle} creator={c} />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/fan/dashboard/page.tsx
+++ b/frontend/src/app/fan/dashboard/page.tsx
@@ -1,29 +1,21 @@
-// app/fan/dashboard/page.tsx
-import Link from 'next/link';
-
 export default function FanDashboardPage() {
   return (
-    <main className="min-h-screen bg-white" style={{ fontFamily: 'Montserrat, sans-serif' }}>
-      <header className="bg-[#003737] text-white p-4 flex justify-between items-center">
-        <h1 className="text-2xl">Fan Dashboard</h1>
-        <nav>
-          <Link href="/fan/dashboard" className="px-3 text-[#FFD700]">Dashboard</Link>
-          <Link href="/fan/history" className="px-3 hover:text-[#FFD700]">History</Link>
-          <Link href="/fan/following" className="px-3 hover:text-[#FFD700]">Following</Link>
-          <Link href="/fan/notifications" className="px-3 hover:text-[#FFD700]">Notifications</Link>
-          <Link href="/fan/wallet" className="px-3 hover:text-[#FFD700]">Wallet</Link>
-          <Link href="/" className="px-3 hover:text-[#FFD700]">Logout</Link>
-        </nav>
-      </header>
-      <section className="p-8">
-        <h2 className="text-xl mb-2">Your TipJar Wallet</h2>
-        <p className="mb-4">Balance: <span className="font-bold">$15.00</span> USDC</p>
-        <h2 className="text-xl mb-2">Recent Tips Given</h2>
-        <ul className="list-disc pl-5 text-gray-700">
-          <li>You tipped @Alice $5 on 2025-06-15</li>
-          <li>You tipped @Bob $2 on 2025-06-10</li>
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">Your support</h1>
+      <div className="rounded-2xl border border-white/10 bg-[#140a2a] p-4">
+        <h2 className="font-semibold">Creators you support</h2>
+        <ul className="mt-3 space-y-2 text-sm">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <li
+              key={i}
+              className="flex justify-between border-b border-white/10 py-2 last:border-0"
+            >
+              <span>Creator {i + 1}</span>
+              <span className="text-white/70">{i % 2 ? 3 : 5} tips</span>
+            </li>
+          ))}
         </ul>
-      </section>
-    </main>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/app/learn/page.tsx
+++ b/frontend/src/app/learn/page.tsx
@@ -1,0 +1,25 @@
+export default function LearnPage() {
+  const articles = [
+    { title: "What is TipJar+?", href: "#" },
+    { title: "How to receive your first USDC tip", href: "#" },
+    { title: "NFT badges: Proof of Support", href: "#" },
+    { title: "Fees and transparency", href: "#" },
+  ];
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">Learn</h1>
+      <ul className="mt-4 space-y-3">
+        {articles.map((a) => (
+          <li
+            key={a.title}
+            className="rounded-2xl border border-white/10 bg-[#140a2a] p-4"
+          >
+            <a href={a.href} className="hover:underline">
+              {a.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@/components/Button";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  return (
+    <div className="mx-auto max-w-md">
+      <h1 className="text-2xl font-bold">Welcome back</h1>
+      <form className="mt-4 space-y-4" onSubmit={(e) => e.preventDefault()}>
+        <div>
+          <label className="block text-sm text-white/80">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 w-full rounded-xl border border-white/20 bg-transparent px-3 py-2 outline-none focus:border-white/40"
+            placeholder="you@example.com"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-white/80">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 w-full rounded-xl border border-white/20 bg-transparent px-3 py-2 outline-none focus:border-white/40"
+            placeholder="••••••••"
+          />
+        </div>
+        <Button className="w-full">Log in</Button>
+        <div className="text-center text-sm text-white/70">or</div>
+        <div className="grid grid-cols-2 gap-3">
+          <button className="rounded-xl border border-white/20 px-3 py-2 text-sm hover:bg-white/5">
+            Continue with Google
+          </button>
+          <button className="rounded-xl border border-white/20 px-3 py-2 text-sm hover:bg-white/5">
+            Continue with Twitch
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="grid min-h-[60vh] place-items-center text-center">
+      <div>
+        <h1 className="text-4xl font-extrabold">Lost in the jar (404)</h1>
+        <p className="mt-2 text-white/80">The page you’re looking for took a tip break.</p>
+        <Link
+          href="/"
+          className="mt-4 inline-block rounded-xl border border-white/20 px-4 py-2 hover:bg-white/10"
+        >
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,19 +1,74 @@
-import FeatureCard from "@/components/FeatureCard";
-import TestimonialBlock from "@/components/TestimonialBlock";
-import CTASection from "@/components/CTASection";
+import Link from "next/link";
+import { Button } from "@/components/Button";
 
 export default function Page() {
   return (
-    <main className="bg-[#2e004f] text-white overflow-hidden">
-      <section className="max-w-screen-xl mx-auto px-6 py-16 grid gap-8 md:grid-cols-3">
-        <FeatureCard title="Instant Tips" description="Receive USDC tips instantly worldwide." />
-        <FeatureCard title="1% Fee" description="Keep more of what you earn with low fees." />
-        <FeatureCard title="Secure" description="Stable infrastructure powered by USDC." />
+    <div>
+      {/* Hero */}
+      <section className="grid gap-8 md:grid-cols-2 md:items-center" id="hero">
+        <div>
+          <h1 className="font-[var(--font-mukta)] text-4xl font-extrabold leading-tight md:text-5xl">
+            Tip. Subscribe. <span className="bg-gradient-to-r from-[#6B46C1] to-[#00A8A8] bg-clip-text text-transparent">Own your support.</span>
+          </h1>
+          <p className="mt-4 max-w-xl text-white/80">
+            Direct USDC micro-tips to the creators you love — no gatekeepers, fast payouts, simple onboarding.
+          </p>
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <Link href="/signup"><Button variant="gold">Begin as a creator</Button></Link>
+            <Link href="/explore"><Button variant="outline">Explore creators</Button></Link>
+            <Link href="#how" className="text-sm text-white/70 hover:text-white">How it works</Link>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-[#120a24] p-4">
+          <div className="grid grid-cols-3 gap-3">
+            {Array.from({ length: 9 }).map((_, i) => (
+              <div key={i} className="h-20 rounded-xl bg-gradient-to-br from-[#6B46C1]/30 to-[#00A8A8]/20" />
+            ))}
+          </div>
+        </div>
       </section>
-      <section className="max-w-screen-xl mx-auto px-6 mb-24">
-        <TestimonialBlock quote="TipJar+ lets me focus on creating while fans support me in seconds." author="Alex, digital artist" />
+      {/* Benefits */}
+      <section className="mt-16 grid gap-4 md:grid-cols-4" id="why">
+        {[
+          ["Direct & instant", "Tips go straight to creators with fast settlement."],
+          [
+            "Simple onboarding",
+            "Start with email/OAuth; connect a wallet when you’re ready.",
+          ],
+          ["Borderless by design", "USDC micro-tips that work worldwide."],
+          ["Own your audience", "Your link, your supporters—no opaque feeds."],
+        ].map(([t, s]) => (
+          <div key={t} className="rounded-2xl border border-white/10 bg-[#140a2a] p-4">
+            <h3 className="font-semibold">{t}</h3>
+            <p className="mt-2 text-sm text-white/80">{s}</p>
+          </div>
+        ))}
       </section>
-      <CTASection />
-    </main>
+      {/* How it works */}
+      <section className="mt-16" id="how">
+        <h2 className="text-2xl font-bold">How it works</h2>
+        <ol className="mt-4 grid gap-4 md:grid-cols-3">
+          {[
+            ["Discover", "Find creators you love."],
+            ["Tip in USDC", "Pay by card or crypto."],
+            ["Celebrate", "Leave a message and an optional NFT badge."],
+          ].map(([t, s], i) => (
+            <li key={t} className="rounded-2xl border border-white/10 bg-[#140a2a] p-4">
+              <div className="text-3xl font-bold text-white/40">{i + 1}</div>
+              <h3 className="mt-2 font-semibold">{t}</h3>
+              <p className="text-sm text-white/80">{s}</p>
+            </li>
+          ))}
+        </ol>
+      </section>
+      {/* Trust strip */}
+      <section className="mt-16 rounded-2xl border border-white/10 bg-[#120a24] p-6 text-center">
+        <p className="text-white/80">Built for creators, loved by fans.</p>
+        <div className="mt-3 flex justify-center gap-3">
+          <Link href="/signup"><Button variant="gold">Start now</Button></Link>
+          <Link href="/learn"><Button variant="outline">Learn more</Button></Link>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@/components/Button";
+
+export default function SignupPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [role, setRole] = useState<"creator" | "fan">("creator");
+  return (
+    <div className="mx-auto max-w-md">
+      <h1 className="text-2xl font-bold">Create your account</h1>
+      <form className="mt-4 space-y-4" onSubmit={(e) => e.preventDefault()}>
+        <div>
+          <label className="block text-sm text-white/80">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 w-full rounded-xl border border-white/20 bg-transparent px-3 py-2 outline-none focus:border-white/40"
+            placeholder="you@example.com"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-white/80">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 w-full rounded-xl border border-white/20 bg-transparent px-3 py-2 outline-none focus:border-white/40"
+            placeholder="••••••••"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-white/80">I am</label>
+          <div className="mt-1 flex gap-2">
+            <button
+              type="button"
+              onClick={() => setRole("creator")}
+              className={`rounded-xl px-3 py-2 text-sm ${
+                role === "creator" ? "bg-white/10" : "border border-white/20 hover:bg-white/5"
+              }`}
+            >
+              Creator
+            </button>
+            <button
+              type="button"
+              onClick={() => setRole("fan")}
+              className={`rounded-xl px-3 py-2 text-sm ${
+                role === "fan" ? "bg-white/10" : "border border-white/20 hover:bg-white/5"
+              }`}
+            >
+              Fan
+            </button>
+          </div>
+        </div>
+        <Button className="w-full">Sign up</Button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,16 @@
+"use client";
+import type { ButtonHTMLAttributes, DetailedHTMLProps } from "react";
+import clsx from "clsx";
+
+export type ButtonProps = DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> & {
+  variant?: "gold" | "outline";
+};
+
+export function Button({ variant = "gold", className, ...props }: ButtonProps) {
+  const base = "rounded-xl px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+  const variants: Record<string, string> = {
+    gold: "bg-[#FFD700] text-black hover:bg-[#e6c200]",
+    outline: "border border-white/20 text-white hover:bg-white/10",
+  };
+  return <button className={clsx(base, variants[variant], className)} {...props} />;
+}

--- a/frontend/src/components/CreatorCard.tsx
+++ b/frontend/src/components/CreatorCard.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export interface Creator {
+  handle: string;
+  name: string;
+  bio: string;
+  avatarUrl: string;
+}
+
+export function CreatorCard({ creator }: { creator: Creator }) {
+  return (
+    <Link
+      href={`/creator/${creator.handle}`}
+      className="block rounded-2xl border border-white/10 bg-[#140a2a] p-4 hover:bg-white/5"
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={creator.avatarUrl}
+        alt={creator.name}
+        className="h-16 w-16 rounded-full object-cover"
+      />
+      <h3 className="mt-3 font-semibold">{creator.name}</h3>
+      <p className="text-sm text-white/70">@{creator.handle}</p>
+      <p className="mt-2 text-sm text-white/80">{creator.bio}</p>
+    </Link>
+  );
+}

--- a/frontend/src/components/FanWall.tsx
+++ b/frontend/src/components/FanWall.tsx
@@ -1,0 +1,22 @@
+/* eslint-disable @next/next/no-img-element */
+export interface Fan {
+  id: string;
+  avatarUrl: string;
+  amount: number;
+  timeAgo: string;
+}
+
+export function FanWall({ fans }: { fans: Fan[] }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {fans.map((fan) => (
+        <div key={fan.id} className="relative">
+          <img src={fan.avatarUrl} alt="" className="h-8 w-8 rounded-full object-cover" />
+          <span className="absolute -bottom-1 -right-1 rounded-full bg-[#6B46C1] px-1 text-[10px] text-white">
+            {fan.amount}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/TipModal.tsx
+++ b/frontend/src/components/TipModal.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { TipModal as BaseTipModal } from "./tip/TipModal";
+
+export interface TipModalProps {
+  creator: { name: string; handle: string; avatarUrl?: string };
+  open: boolean;
+  onClose: () => void;
+  children?: React.ReactNode;
+}
+
+export const TipModal = ({ creator, open, onClose, children }: TipModalProps) => {
+  return (
+    <BaseTipModal
+      creator={{ name: creator.name, avatar: creator.avatarUrl }}
+      isOpen={open}
+      onClose={onClose}
+    >
+      {children}
+    </BaseTipModal>
+  );
+};


### PR DESCRIPTION
## Summary
- implement landing page with hero, benefits, how-it-works and trust sections
- add explore, learn, login, signup, and dashboard pages
- introduce Button, CreatorCard, FanWall, and TipModal utilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error in src/app/(auth)/login/page.tsx)*
- `npm run build` *(interrupted after starting Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_689babb293988327bfd85e29c1369672