### PR TITLE
Fix root layout markup

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,4 @@
-"use client";
-
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactNode } from 'react';
 import './globals.css';
 import type { Metadata } from 'next';
 
@@ -18,15 +16,13 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
-  const [bgClass, setBgClass] = useState('');
-
-  useEffect(() => {
-    const randomClass = bgClasses[Math.floor(Math.random() * bgClasses.length)];
-    setBgClass(randomClass);
-  }, []);
+  const bgClass = bgClasses[Math.floor(Math.random() * bgClasses.length)];
 
   return (
-
+    <html lang="en">
+      <body
+        className={`${bgClass} ${ibm.variable} ${inter.variable} ${mukta.variable} ${playfair.variable}`}
+      >
         {/*
           Opakowujemy całą aplikację w Providers.
           To sprawia, że hooki z wagmi (do obsługi portfela)


### PR DESCRIPTION
## Summary
- define root layout markup with html and body elements
- apply font variables and random background class on the body

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing errors in other files)*
- `npm run build` *(fails: unable to fetch font files; routing conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_689beaad17b4832782e3763974e1cbd5