### PR TITLE
Integrate frontend with backend API

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { login, me } from "@/lib/auth";
+import { Toast } from "@/components/ui/Toast";
+
+export default function Page() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null); setLoading(true);
+    try {
+      await login({ email, password });
+      const user = await me().catch(() => null);
+      const hasUsername = !!(user && (user.username || user.handle));
+      router.push(hasUsername ? "/fan/feed" : "/onboarding/username");
+    } catch (e: any) {
+      setError(e.message || "Login failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[#001F1F] p-6">
+      {error && <Toast msg={error} onClose={() => setError(null)} />}
+      <div className="mx-auto max-w-md rounded-2xl border border-white/10 bg-white/5 p-6">
+        <h1 className="font-sans text-2xl font-bold text-white">Sign in</h1>
+        <form onSubmit={onSubmit} className="mt-4 space-y-3">
+          <input value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="Email" className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-[#FFD700]"/>
+          <input value={password} onChange={(e)=>setPassword(e.target.value)} type="password" placeholder="Password" className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-[#FFD700]"/>
+          <button disabled={loading} className="font-ui w-full rounded-xl bg-[#FFD700] px-4 py-3 font-semibold text-[#003737] disabled:opacity-60">{loading?"Processing…":"Sign in"}</button>
+        </form>
+        <p className="mt-3 text-sm text-[#BCC1B6]"><a className="underline" href="/register">Nie masz konta?</a></p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { register, me } from "@/lib/auth";
+import { Toast } from "@/components/ui/Toast";
+
+export default function Page() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null); setLoading(true);
+    try {
+      await register({ email, password, displayName: displayName || undefined });
+      const user = await me().catch(() => null);
+      const hasUsername = !!(user && (user.username || user.handle));
+      router.push(hasUsername ? "/fan/feed" : "/onboarding/username");
+    } catch (e: any) {
+      setError(e.message || "Registration failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[#001F1F] p-6">
+      {error && <Toast msg={error} onClose={() => setError(null)} />}
+      <div className="mx-auto max-w-md rounded-2xl border border-white/10 bg-white/5 p-6">
+        <h1 className="font-sans text-2xl font-bold text-white">Create account</h1>
+        <form onSubmit={onSubmit} className="mt-4 space-y-3">
+          <input value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="Email" className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-[#FFD700]"/>
+          <input value={displayName} onChange={(e)=>setDisplayName(e.target.value)} placeholder="Display name (optional)" className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-[#FFD700]"/>
+          <input value={password} onChange={(e)=>setPassword(e.target.value)} type="password" placeholder="Password" className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-[#FFD700]"/>
+          <button disabled={loading} className="font-ui w-full rounded-xl bg-[#FFD700] px-4 py-3 font-semibold text-[#003737] disabled:opacity-60">{loading?"Processing…":"Create account"}</button>
+        </form>
+        <p className="mt-3 text-sm text-[#BCC1B6]"><a className="underline" href="/login">Masz konto?</a></p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/tip/[handle]/page.tsx
+++ b/frontend/src/app/tip/[handle]/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { useState } from "react";
+import { sendTip } from "@/lib/tips";
+import { Toast } from "@/components/ui/Toast";
+import { useRouter } from "next/navigation";
+
+export default function Page({ params }: { params: { handle: string } }) {
+  const router = useRouter();
+  const { handle } = params;
+  const [amount, setAmount] = useState("5.00");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onSend() {
+    setError(null);
+    setLoading(true);
+    try {
+      const payload = { creatorId: handle, amount };
+      const { tip } = await sendTip(payload);
+      const tx = tip?.txHash || tip?.tx || tip?.id || "tx_demo";
+      router.push(`/tip/${handle}/success?amt=${encodeURIComponent(amount)}&tx=${encodeURIComponent(String(tx))}`);
+    } catch (e: any) {
+      setError(e.message || "Payment failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[#001F1F] p-6 text-white">
+      {error && <Toast msg={error} onClose={() => setError(null)} />}
+      <div className="mx-auto max-w-md space-y-4">
+        <h1 className="text-xl font-semibold">Tip @{handle}</h1>
+        <input
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-white"
+        />
+        <button
+          disabled={loading}
+          onClick={onSend}
+          className="font-ui w-full rounded-xl bg-[#FFD700] px-4 py-3 font-semibold text-[#003737] disabled:opacity-60"
+        >
+          {loading ? "Processing…" : "Send tip"}
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/tip/[handle]/success/page.tsx
+++ b/frontend/src/app/tip/[handle]/success/page.tsx
@@ -1,0 +1,34 @@
+import Receipt from "@/components/tip/Receipt";
+import Link from "next/link";
+
+export default function Page({ params, searchParams }: { params: { handle: string }, searchParams: { amt?: string; tx?: string } }) {
+  const handle = params.handle;
+  const amount = normAmt(searchParams?.amt);
+  const tx = String(searchParams?.tx || "");
+
+  if (!amount || !tx) {
+    return (
+      <main className="grid min-h-[60vh] place-items-center bg-[#001F1F] p-6 text-white">
+        <div className="max-w-md text-center">
+          <p className="text-white/90">Missing transaction data.</p>
+          <Link href={`/tip/${handle}`} className="mt-4 inline-block font-ui rounded-xl bg-[#FFD700] px-4 py-2 font-semibold text-[#003737]">Back to tip</Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-[#001F1F] p-6">
+      <div className="mx-auto max-w-2xl">
+        <Receipt handle={handle} amount={amount} tx={tx} />
+      </div>
+    </main>
+  );
+}
+
+function normAmt(a?: string) {
+  if (!a) return "";
+  const n = Number(a);
+  if (!isFinite(n) || n <= 0) return "";
+  return n.toFixed(2);
+}

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useEffect, useState } from "react";
+import { me } from "@/lib/auth";
+import { useRouter } from "next/navigation";
+
+export default function RequireAuth({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const [state, setState] = useState<"loading"|"ok"|"redir">("loading");
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const u = await me();
+        if (!alive) return;
+        if (u && (u.id || u.email)) setState("ok"); else { setState("redir"); router.replace("/login"); }
+      } catch {
+        setState("redir");
+        router.replace("/login");
+      }
+    })();
+    return () => { alive = false; };
+  }, [router]);
+
+  if (state === "loading") return <div className="grid min-h-[40vh] place-items-center text-sm text-white/70">Checking session…</div>;
+  if (state === "redir") return null;
+  return <>{children}</>;
+}

--- a/frontend/src/components/tip/Receipt.tsx
+++ b/frontend/src/components/tip/Receipt.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+
+export default function Receipt({ handle, amount, tx }: { handle: string; amount: string; tx: string }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-white">
+      <h2 className="text-xl font-semibold">Thanks for your tip!</h2>
+      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Info label="Creator" value={`@${handle}`} />
+        <Info label="Amount" value={`${amount} USDC`} />
+        <Info label="Transaction" value={<TxHash hash={tx} />} />
+        <Info label="Date" value={new Date().toLocaleString()} />
+      </div>
+      <div className="mt-6 flex flex-wrap gap-3">
+        <Link href={`/tip/${handle}`} className="font-ui rounded-xl border border-white/15 px-4 py-2 font-semibold text-white/90">Tip again</Link>
+        <Share amount={amount} handle={handle} />
+      </div>
+    </div>
+  );
+}
+
+function Info({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="rounded-xl bg-white/5 p-4">
+      <p className="text-xs text-[#BCC1B6]">{label}</p>
+      <div className="mt-1 text-sm text-white/90 break-all">{value}</div>
+    </div>
+  );
+}
+
+function TxHash({ hash }: { hash: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <code className="text-[12px]">{short(hash)}</code>
+      <button
+        onClick={() => navigator.clipboard?.writeText(hash)}
+        className="font-ui rounded-lg border border-white/15 px-2 py-1 text-[12px] text-white/80 hover:bg-white/10"
+      >Copy</button>
+    </div>
+  );
+}
+
+function Share({ amount, handle }: { amount: string; handle: string }) {
+  const text = encodeURIComponent(`I just tipped @${handle} ${amount} USDC on tipjar+ ✨`);
+  return (
+    <a
+      href={`https://twitter.com/intent/tweet?text=${text}`}
+      target="_blank" rel="noopener noreferrer"
+      className="font-ui rounded-xl bg-[#FFD700] px-4 py-2 font-semibold text-[#003737]"
+    >Share</a>
+  );
+}
+
+function short(tx: string) { return tx.length > 16 ? `${tx.slice(0, 8)}…${tx.slice(-6)}` : tx; }

--- a/frontend/src/components/ui/Bell.tsx
+++ b/frontend/src/components/ui/Bell.tsx
@@ -1,0 +1,21 @@
+"use client";
+import Link from "next/link";
+
+export default function Bell({ count = 0, href = "/fan/notifications", title = "Notifications" }: { count?: number; href?: string; title?: string }) {
+  return (
+    <Link
+      href={href}
+      aria-label={title}
+      className="relative inline-flex h-9 w-9 items-center justify-center rounded-xl border border-white/10 bg-white/5 text-white/90 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-[#FFD700]"
+    >
+      <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden>
+        <path d="M12 22a2 2 0 0 0 2-2H10a2 2 0 0 0 2 2Zm8-6v-5a8 8 0 1 0-16 0v5l-2 2v1h20v-1l-2-2Z" fill="currentColor"/>
+      </svg>
+      {count > 0 && (
+        <span className="absolute -right-1 -top-1 min-w-[20px] rounded-full bg-[#FFD700] px-1.5 text-center text-[11px] font-bold text-[#003737]">
+          {count > 99 ? '99+' : count}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/frontend/src/components/ui/FormError.tsx
+++ b/frontend/src/components/ui/FormError.tsx
@@ -1,0 +1,9 @@
+"use client";
+export default function FormError({ message }: { message?: string }) {
+  if (!message) return null;
+  return (
+    <p role="alert" className="mt-2 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+      {message}
+    </p>
+  );
+}

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { useEffect, useState } from 'react';
+
+export function Toast({ msg, onClose }: { msg: string; onClose?: () => void }) {
+  const [open, setOpen] = useState(true);
+  useEffect(() => {
+    const id = setTimeout(() => { setOpen(false); onClose?.(); }, 4000);
+    return () => clearTimeout(id);
+  }, [onClose]);
+  if (!open) return null;
+  return (
+    <div className="fixed bottom-4 left-1/2 z-[9999] -translate-x-1/2 rounded-xl bg-black/80 px-4 py-3 text-sm text-white shadow-xl ring-1 ring-white/20">
+      {msg}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,47 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { http } from "@/lib/http";
+import { API } from "@/lib/api-routes";
+
+export type NotificationItem = {
+  id?: string | number;
+  title?: string;
+  type?: string;
+  createdAt?: string;
+  date?: string;
+  read?: boolean;
+};
+
+type Options = { intervalMs?: number };
+
+export function useNotifications(opts: Options = {}) {
+  const interval = opts.intervalMs ?? 20000;
+  const [items, setItems] = useState<NotificationItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const timer = useRef<any>(null);
+
+  async function load() {
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await http(API.NOTIFICATIONS);
+      const list = Array.isArray(res) ? res : (res?.items || []);
+      setItems(list);
+    } catch (e: any) {
+      setError(e.message || "Failed to fetch notifications");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    let alive = true;
+    (async () => { if (alive) await load(); })();
+    timer.current = setInterval(load, interval);
+    return () => { alive = false; clearInterval(timer.current); };
+  }, [interval]);
+
+  const unread = items.filter(i => i.read === false).length;
+  return { items, unread, loading, error, reload: load };
+}

--- a/frontend/src/lib/api-routes.ts
+++ b/frontend/src/lib/api-routes.ts
@@ -1,0 +1,41 @@
+export const API = {
+  AUTH: {
+    REGISTER:   "/api/v1/auth/register",
+    LOGIN:      "/api/v1/auth/login",
+    GOOGLE:     "/api/v1/auth/google",
+    GOOGLE_CB:  "/api/v1/auth/google/callback",
+    TWITCH:     "/api/v1/auth/twitch",
+    TWITCH_CB:  "/api/v1/auth/twitch/callback",
+    ME:         "/api/v1/auth/me",
+    VERIFY:     "/api/v1/auth/verify-email/:token",
+    REFRESH:    "/api/v1/auth/refresh-token",
+    LOGOUT:     "/api/v1/auth/logout",
+  },
+  USERS: {
+    USERNAME_CHECK: "/api/v1/users/username-check",
+    SET_USERNAME:   "/api/v1/users/set-username",
+  },
+  TIPS: {
+    CREATE: "/api/v1/tips",
+    GUEST:  "/api/v1/tips/guest",
+  },
+  CREATOR: {
+    PAYOUT: "/api/v1/creator/payout",
+  },
+  CIRCLE: {
+    WALLET_CREATE:   "/api/v1/api/v1/circle/wallet/create",
+    WALLET:          "/api/v1/api/v1/circle/wallet",
+    BALANCE:         "/api/v1/api/v1/circle/wallet/balance",
+    TXS:             "/api/v1/api/v1/circle/wallet/transactions",
+    DEPOSIT_HOSTED:  "/api/v1/api/v1/circle/deposit-hosted",
+    WITHDRAW:        "/api/v1/api/v1/circle/withdraw",
+    CCTP_TRANSFER:   "/api/v1/api/v1/circle/cctp/transfer",
+    WEBHOOK:         "/api/v1/api/v1/circle/webhook",
+    ADMIN_WALLETS:   "/api/v1/api/v1/circle/admin/circle/wallets",
+  },
+  FAN: {
+    BALANCE:      "/api/v1/api/v1/fan/wallet/balance",
+    TIPS_HISTORY: "/api/v1/api/v1/fan/tips/history",
+  },
+  NOTIFICATIONS: "/api/v1/api/v1/notifications",
+} as const;

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,21 @@
+import { http } from "./http";
+import { API } from "./api-routes";
+
+export type RegisterDto = { email: string; password: string; displayName?: string };
+export type LoginDto = { email: string; password: string };
+
+export async function register(dto: RegisterDto) {
+  return http(API.AUTH.REGISTER, { method: "POST", json: dto });
+}
+export async function login(dto: LoginDto) {
+  return http(API.AUTH.LOGIN, { method: "POST", json: dto });
+}
+export async function me() {
+  return http(API.AUTH.ME, { method: "GET" });
+}
+export async function refresh() {
+  return http(API.AUTH.REFRESH, { method: "POST" });
+}
+export async function logout() {
+  return http(API.AUTH.LOGOUT, { method: "POST" });
+}

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -1,0 +1,16 @@
+export type UiError = { message: string; code?: number; details?: unknown };
+
+export function toUiError(e: unknown, fallback = "Something went wrong"): UiError {
+  if (!e) return { message: fallback };
+  if (typeof e === 'string') return { message: e };
+  if (e instanceof Error) return { message: e.message || fallback };
+  try {
+    const any = e as any;
+    const msg = any?.message || any?.error || any?.data?.message || fallback;
+    const code = any?.status || any?.code || any?.data?.code;
+    const details = any?.errors || any?.data?.errors;
+    return { message: String(msg), code: Number(code) || undefined, details };
+  } catch {
+    return { message: fallback };
+  }
+}

--- a/frontend/src/lib/http.ts
+++ b/frontend/src/lib/http.ts
@@ -1,0 +1,30 @@
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || ""; // np. ""
+
+export type FetchOpts = RequestInit & { json?: any };
+
+export async function http(path: string, opts: FetchOpts = {}) {
+  const url = path.startsWith("http") ? path : `${API_BASE}${path}`;
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    ...(opts.json ? { 'Content-Type': 'application/json' } : {}),
+    ...(opts.headers as Record<string, string>),
+  };
+  const res = await fetch(url, {
+    credentials: 'include',
+    ...opts,
+    headers,
+    body: opts.json ? JSON.stringify(opts.json) : opts.body,
+  });
+  let data: any = null;
+  const text = await res.text();
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = text;
+  }
+  if (!res.ok) {
+    const message = (data && (data.message || data.error)) || `HTTP ${res.status}`;
+    throw new Error(message);
+  }
+  return data;
+}

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,0 +1,6 @@
+import { http } from "./http";
+import { API } from "./api-routes";
+
+export async function fetchNotifications() {
+  return http(API.NOTIFICATIONS, { method: "GET" });
+}

--- a/frontend/src/lib/payouts.ts
+++ b/frontend/src/lib/payouts.ts
@@ -1,0 +1,8 @@
+import { http } from "./http";
+import { API } from "./api-routes";
+
+export type PayoutDto = { amount: string };
+
+export async function createPayout(dto: PayoutDto) {
+  return http(API.CREATOR.PAYOUT, { method: "POST", json: dto });
+}

--- a/frontend/src/lib/tips.ts
+++ b/frontend/src/lib/tips.ts
@@ -1,0 +1,23 @@
+import { http } from './http';
+
+export type TipPayload = {
+  creatorId: string;        // ID twórcy (backend)
+  amount: string;           // amount jako string (np. "5.00")
+  note?: string;            // opcjonalnie wiadomość do twórcy
+};
+
+export type GuestExtras = {
+  paymentGatewayToken?: string; // token z on-rampa (fiat)
+};
+
+export async function sendTip(payload: TipPayload, guest?: GuestExtras) {
+  try {
+    const tip = await http('/api/v1/tips', { method: 'POST', json: payload });
+    return { tip, guest: false };
+  } catch (e: any) {
+    if (!/401|unauthorized/i.test(e.message)) throw e;
+    const body = { ...payload, ...(guest || {}) };
+    const tip = await http('/api/v1/tips/guest', { method: 'POST', json: body });
+    return { tip, guest: true };
+  }
+}

--- a/frontend/src/lib/users.ts
+++ b/frontend/src/lib/users.ts
@@ -1,0 +1,10 @@
+import { http } from "./http";
+import { API } from "./api-routes";
+
+export async function checkUsername(u: string) {
+  const q = new URLSearchParams({ username: u }).toString();
+  return http(`${API.USERS.USERNAME_CHECK}?${q}`);
+}
+export async function setUsername(username: string) {
+  return http(API.USERS.SET_USERNAME, { method: "POST", json: { username } });
+}

--- a/frontend/src/lib/wallet.ts
+++ b/frontend/src/lib/wallet.ts
@@ -1,0 +1,29 @@
+import { http } from "./http";
+import { API } from "./api-routes";
+
+export async function createWallet() {
+  return http(API.CIRCLE.WALLET_CREATE, { method: "POST" });
+}
+export async function getWallet() {
+  return http(API.CIRCLE.WALLET, { method: "GET" });
+}
+export async function getBalance() {
+  return http(API.CIRCLE.BALANCE, { method: "GET" });
+}
+export async function getTransactions() {
+  return http(API.CIRCLE.TXS, { method: "GET" });
+}
+export async function depositHosted(amount: string) {
+  return http(API.CIRCLE.DEPOSIT_HOSTED, { method: "POST", json: { amount } });
+}
+export async function withdraw(amount: string) {
+  return http(API.CIRCLE.WITHDRAW, { method: "POST", json: { amount } });
+}
+export type CctpDto = {
+  destinationChain: string;
+  destinationAddress: string;
+  amount: string;
+};
+export async function cctpTransfer(dto: CctpDto) {
+  return http(API.CIRCLE.CCTP_TRANSFER, { method: "POST", json: dto });
+}


### PR DESCRIPTION
## Summary
- add HTTP wrapper with JSON handling and cookie credentials
- implement Tip API client with guest fallback on 401 responses
- add toast UI component and tip pages with success receipt

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ab7f8b81a88327b5bafe2905f9a319