### PR TITLE
feat: add explorer spotlight and navigation alias

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.30.0",
+        "@playwright/test": "^1.51.1",
         "@tailwindcss/postcss": "^4.1.11",
         "@types/next": "^8.0.7",
         "@types/node": "^24.0.1",
@@ -2298,6 +2299,22 @@
       "license": "(MIT OR Apache-2.0)",
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/colors": {
@@ -13220,6 +13237,53 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
       "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/pngjs": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "clean": "rm -rf .next"
+    "clean": "rm -rf .next",
+    "test": "playwright test"
   },
   "dependencies": {
     "@chainsafe/circle-react-elements": "^0.1.2",
@@ -58,6 +59,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.5.2",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "@playwright/test": "^1.51.1"
   }
 }

--- a/frontend/src/app/discover/page.tsx
+++ b/frontend/src/app/discover/page.tsx
@@ -1,31 +1,248 @@
-// app/discover/page.tsx
-import Link from "next/link";
+import Page from "@/components/ui/Page";
+import Card from "@/components/ui/Card";
+import SearchBox, { type SearchResult } from "@/components/discover/SearchBox";
+import CreatorCard from "@/components/discover/CreatorCard";
+import { collections } from "@/data/collections";
+import CollectionCard from "@/components/explorer/CollectionCard";
+import SortSelect from "@/components/explorer/SortSelect";
+import FilterChips from "@/components/explorer/FilterChips";
+import Suggestions from "@/components/explorer/Suggestions";
+import TrendingClient from "@/components/explorer/TrendingClient";
+import YourPicks from "@/components/explorer/YourPicks";
+import FeaturedGrid from "@/components/explorer/FeaturedGrid";
+import Spotlight from "@/components/explorer/Spotlight";
+import {
+  flattenCollections,
+  applyFilters,
+  sortCreators,
+  paginate,
+  type ExplorerSort,
+  topTags,
+} from "@/lib/explorer";
 
-export default function DiscoverPage() {
-  const creators = ["Alice", "Bob", "Charlie", "Dave", "Eve"];
+export const metadata = {
+  title: "Discover — tipjar+",
+  alternates: { canonical: "/discover" },
+};
+
+export default function PageDiscover() {
+  const items: SearchResult[] = [];
   return (
-    <main
-      className="min-h-screen bg-white p-8"
-      style={{ fontFamily: "Montserrat, sans-serif" }}
-    >
-      <h1 className="text-4xl font-bold text-[#003737] mb-4">
-        Discover Creators
-      </h1>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {creators.map((creator) => (
-          <div key={creator} className="border p-4 rounded-lg shadow-sm">
-            <h2 className="text-xl mb-2">@{creator}</h2>
-            <p className="mb-4 text-gray-600">
-              Bio or short description of {creator}.
-            </p>
-            <Link href={`/@${creator}`}>
-              <button className="bg-[#FFD700] text-[#003737] py-2 px-4 rounded">
-                View Profile
-              </button>
-            </Link>
-          </div>
+    <Page>
+      <div className="mx-auto max-w-5xl space-y-6">
+        <Card>
+          <h1 className="text-2xl font-bold text-white">Discover creators</h1>
+          <p className="mt-1 text-[#DDE0DA]">
+            Wpisz @handle lub przeglądaj kuratorowane kolekcje.
+          </p>
+        </Card>
+        {collections.length > 0 && (
+          <Spotlight
+            pool={sortCreators(flattenCollections(collections), "trending")
+              .slice(0, 20)
+              .map((c) => ({
+                handle: c.handle,
+                score: c.score,
+                avatarUrl: c.avatarUrl,
+                live: c.live,
+              }))}
+          />
+        )}
+        {collections.length > 0 && (
+          <FeaturedGrid
+            items={sortCreators(flattenCollections(collections), "trending")
+              .slice(0, 3)
+              .map((c) => ({
+                handle: c.handle,
+                score: c.score,
+                tags: c.tags,
+                collections: c.collections,
+                avatarUrl: c.avatarUrl,
+                live: c.live,
+              }))}
+          />
+        )}
+        {collections.length > 0 && (
+          <TrendingClient
+            items={sortCreators(flattenCollections(collections), "trending")
+              .slice(0, 24)
+              .map((c) => ({ handle: c.handle, score: c.score }))}
+          />
+        )}
+        <YourPicks />
+        <Client initial={items} />
+        {collections.length > 0 && (
+          <section className="space-y-4">
+            <h2 className="text-xl font-semibold text-white">Kolekcje</h2>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {collections.map((c) => (
+                <CollectionCard
+                  key={c.slug}
+                  title={c.title}
+                  description={c.description}
+                  handles={c.handles}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+        <AllCreators />
+      </div>
+    </Page>
+  );
+}
+
+"use client";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import TopTagsCloud from "@/components/explorer/TopTagsCloud";
+import type { Suggestion } from "@/components/explorer/Suggestions";
+import { collections as D } from "@/data/collections";
+
+function Client({ initial }: { initial: SearchResult[] }) {
+  const [direct, setDirect] = useState<SearchResult[]>(initial);
+  const [q, setQ] = useState("");
+
+  const suggest = useSuggestions(q);
+
+  return (
+    <section className="space-y-4">
+      <SearchBox onResults={(rows) => setDirect(rows)} onQueryChange={setQ} />
+      {q && <Suggestions items={suggest} query={q} />}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {direct.map((it) => (
+          <CreatorCard
+            key={it.handle}
+            handle={it.handle}
+            exists={it.exists}
+          />
         ))}
       </div>
-    </main>
+    </section>
   );
+}
+
+function AllCreators() {
+  const cats = collections.map((c) => ({ slug: c.slug, title: c.title }));
+  const base = useMemo(() => flattenCollections(collections), []);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [tagSel, setTagSel] = useState<string[]>([]);
+  const [sort, setSort] = useState<ExplorerSort>("trending");
+  const [page, setPage] = useState(1);
+  const [query, setQuery] = useState("");
+
+  function GridFilter() {
+    return (
+      <input
+        value={query}
+        onChange={(e) => {
+          setPage(1);
+          setQuery(e.target.value);
+        }}
+        placeholder="Filter handles…"
+        className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-[#FFD700]"
+      />
+    );
+  }
+
+  const filtered = useMemo(
+    () => applyFilters(base, { categories: selected, tags: tagSel, query }),
+    [base, selected, tagSel, query]
+  );
+  const sorted = useMemo(() => sortCreators(filtered, sort), [filtered, sort]);
+  const { items, total, hasMore } = useMemo(
+    () => paginate(sorted, page, 12),
+    [sorted, page]
+  );
+
+  const onToggle = useCallback((slug: string) => {
+    setPage(1);
+    setSelected((prev) =>
+      prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug]
+    );
+  }, []);
+
+  useEffect(() => {
+    setPage(1);
+  }, [sort]);
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-xl font-semibold text-white">All creators</h2>
+        <SortSelect value={sort} onChange={setSort} />
+      </div>
+      {cats.length > 0 && (
+        <FilterChips categories={cats} selected={selected} onToggle={onToggle} />
+      )}
+      <TopTagsCloud
+        items={useMemo(() => topTags(base, 16), [base])}
+        selected={tagSel}
+        onToggle={(tag) => {
+          setPage(1);
+          setTagSel((prev) =>
+            prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+          );
+        }}
+      />
+      <GridFilter />
+      <p className="text-xs text-[#BCC1B6]">
+        Showing {Math.min(items.length + (page - 1) * 12, total)} of {total}
+      </p>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((c) => (
+          <CreatorCard
+            key={c.handle}
+            handle={c.handle}
+            exists={true}
+            score={c.score}
+            tags={c.tags}
+            collections={c.collections}
+            avatarUrl={c.avatarUrl}
+            live={c.live}
+          />
+        ))}
+        {items.length === 0 && (
+          <p className="text-sm text-[#BCC1B6]">No matches.</p>
+        )}
+      </div>
+      {hasMore && (
+        <div className="mt-2">
+          <button
+            onClick={() => setPage((p) => p + 1)}
+            className="rounded-xl border border-white/15 bg-white/5 px-4 py-2 text-sm text-white hover:bg-white/10"
+          >
+            Load more
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function useSuggestions(q: string): Suggestion[] {
+  const s = (q || "").trim().toLowerCase();
+  if (s.length < 2) return [];
+  const fromLocal = Array.from(
+    new Set(
+      (D || [])
+        .flatMap((c) => (c.handles || []).map((h: any) => (typeof h === "string" ? h : h.handle)))
+        .filter(Boolean)
+    )
+  )
+    .filter((h) => h.toLowerCase().includes(s))
+    .slice(0, 5)
+    .map((handle) => ({ handle, source: "local" as const }));
+
+  let recent: string[] = [];
+  try {
+    recent = JSON.parse(localStorage.getItem("tj_recent_searches") || "[]");
+  } catch {}
+  const fromRecent = recent
+    .filter((h) => (h || "").toLowerCase().includes(s))
+    .slice(0, 5)
+    .map((handle) => ({ handle, source: "recent" as const }));
+
+  const map = new Map<string, Suggestion>();
+  [...fromLocal, ...fromRecent].forEach((it) => map.set(it.handle, it));
+  return Array.from(map.values()).slice(0, 5);
 }

--- a/frontend/src/app/explore/page.tsx
+++ b/frontend/src/app/explore/page.tsx
@@ -1,0 +1,18 @@
+export { default } from "@/app/discover/page";
+
+export const metadata = {
+  title: "Explorer — tipjar+",
+  description:
+    "Znajdź twórców, trendujące profile, tagi i kuratorowane kolekcje. Jednym kliknięciem wyślij napiwek.",
+  alternates: { canonical: "/explore" },
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "Explorer — tipjar+",
+    description: "Trendujące profile, tagi i kolekcje. Odkrywaj i tipuj szybciej.",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Explorer — tipjar+",
+    description: "Odkrywaj twórców i wysyłaj napiwki natychmiast.",
+  },
+};

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -13,6 +13,9 @@ const Footer = () => (
       <a href="#examples" className="mx-2 hover:underline">
         Examples
       </a>
+      <a href="/explore" className="mx-2 hover:underline">
+        Explore
+      </a>
     </div>
     <div className="mb-2">
       <a href="#" className="mx-2 hover:underline">

--- a/frontend/src/components/discover/CreatorCard.tsx
+++ b/frontend/src/components/discover/CreatorCard.tsx
@@ -1,0 +1,103 @@
+import Card from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import { initials, gradientStyle } from "@/lib/avatar";
+import { recordClick } from "@/lib/metrics";
+
+type Props = {
+  handle: string;
+  exists: boolean;
+  score?: number;
+  tags?: string[];
+  collections?: string[];
+  avatarUrl?: string;
+  live?: boolean;
+};
+
+export default function CreatorCard({
+  handle,
+  exists,
+  score,
+  tags,
+  collections,
+  avatarUrl,
+  live,
+}: Props) {
+  const hasMeta = (tags && tags.length > 0) || typeof score === "number";
+  const url = exists ? `/tip/${handle}` : "/register";
+
+  return (
+    <Card>
+      <div className="flex items-start justify-between gap-3">
+        <div className="relative mr-2 h-12 w-12 shrink-0 overflow-hidden rounded-full border border-white/10">
+          {avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              alt={`Avatar of @${handle}`}
+              src={avatarUrl}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div
+              className="grid h-full w-full place-items-center text-sm font-semibold text-white/90"
+              style={gradientStyle(handle)}
+              aria-hidden="true"
+            >
+              {initials(handle)}
+            </div>
+          )}
+          {live && (
+            <span
+              title="LIVE"
+              className="absolute -right-1 -top-1 inline-flex items-center gap-1 rounded-full bg-[#FF365E] px-2 py-0.5 text-[10px] font-bold text-white shadow"
+            >
+              <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-white" />
+              LIVE
+            </span>
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <p className="text-xs text-[#BCC1B6]">Creator</p>
+          <h3 className="truncate text-lg font-semibold text-white">@{handle}</h3>
+
+          {hasMeta && (
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              {typeof score === "number" && (
+                <span
+                  className="inline-flex items-center rounded-full border border-[#FFD700] bg-[#FFD700]/20 px-2 py-0.5 text-[11px] font-semibold text-[#FFD700]"
+                  title="Trending score"
+                >
+                  ★ {Math.max(0, Math.min(100, Math.round(score)))}
+                </span>
+              )}
+              {(tags ?? []).slice(0, 4).map((t) => (
+                <span
+                  key={t}
+                  className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[11px] text-white/80"
+                >
+                  #{t}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {collections && collections.length > 0 && (
+            <p className="mt-1 truncate text-[11px] text-white/50">
+              in: {collections.slice(0, 3).join(", ")}
+              {collections.length > 3 ? "…" : ""}
+            </p>
+          )}
+        </div>
+
+        <a
+          href={url}
+          className="font-ui"
+          aria-label={exists ? `Tip @${handle}` : `Claim handle @${handle}`}
+          onClick={() => recordClick(handle, "creator-card")}
+        >
+          <Button>{exists ? "Tip now" : "Claim @handle"}</Button>
+        </a>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/discover/SearchBox.tsx
+++ b/frontend/src/components/discover/SearchBox.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+
+export type SearchResult = { handle: string; exists: boolean };
+
+export default function SearchBox({
+  onResults,
+  onQueryChange,
+}: {
+  onResults: (rows: SearchResult[]) => void;
+  onQueryChange?: (q: string) => void;
+}) {
+  const [value, setValue] = useState("");
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const q = e.target.value;
+    setValue(q);
+    onQueryChange?.(q);
+    if (q.startsWith("@")) {
+      onResults([{ handle: q.slice(1), exists: true }]);
+    } else {
+      onResults([]);
+    }
+  }
+
+  return (
+    <input
+      value={value}
+      onChange={handleChange}
+      placeholder="Search @handle"
+      className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white placeholder:text-white/40 focus:outline-none focus:ring-2 focus:ring-[#FFD700]"
+    />
+  );
+}

--- a/frontend/src/components/explorer/CollectionCard.tsx
+++ b/frontend/src/components/explorer/CollectionCard.tsx
@@ -1,0 +1,56 @@
+import Card from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import CreatorCard from "@/components/discover/CreatorCard";
+import type { HandleEntry } from "@/data/collections";
+
+export default function CollectionCard({
+  title,
+  description,
+  handles,
+}: {
+  title: string;
+  description?: string;
+  handles: HandleEntry[];
+}) {
+  const first = handles.slice(0, 3);
+  return (
+    <Card>
+      <div className="mb-3">
+        <h3 className="text-lg font-semibold text-white">{title}</h3>
+        {description && <p className="text-sm text-[#BCC1B6]">{description}</p>}
+      </div>
+      {first.length === 0 ? (
+        <p className="text-sm text-[#BCC1B6]">Brak elementów w tej kolekcji.</p>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {first.map((h) => {
+            const handle = typeof h === "string" ? h : h.handle;
+            const score = typeof h === "string" ? undefined : h.score;
+            const tags = typeof h === "string" ? undefined : h.tags;
+            const avatarUrl = typeof h === "string" ? undefined : h.avatarUrl;
+            const live = typeof h === "string" ? undefined : h.live;
+            return (
+              <CreatorCard
+                key={handle}
+                handle={handle}
+                exists={true}
+                score={score}
+                tags={tags}
+                avatarUrl={avatarUrl}
+                live={live}
+              />
+            );
+          })}
+        </div>
+      )}
+      <div className="mt-4">
+        <a
+          href={`/discover?collection=${encodeURIComponent(title)}`}
+          className="font-ui"
+        >
+          <Button variant="secondary">Zobacz więcej</Button>
+        </a>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/explorer/FeaturedGrid.tsx
+++ b/frontend/src/components/explorer/FeaturedGrid.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import FeaturedHero from "./FeaturedHero";
+import CreatorCard from "@/components/discover/CreatorCard";
+
+export type Item = {
+  handle: string;
+  score?: number;
+  tags?: string[];
+  collections?: string[];
+  avatarUrl?: string;
+  live?: boolean;
+};
+
+export default function FeaturedGrid({ items }: { items: Item[] }) {
+  if (!items?.length) return null;
+  const [first, second, third] = items.slice(0, 3);
+  if (!first) return null;
+
+  return (
+    <section className="space-y-3">
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="md:col-span-2">
+          <FeaturedHero
+            handle={first.handle}
+            score={first.score}
+            avatarUrl={first.avatarUrl}
+            live={first.live}
+          />
+        </div>
+        <div className="space-y-3">
+          {second && (
+            <CreatorCard
+              handle={second.handle}
+              exists={true}
+              score={second.score}
+              tags={second.tags}
+              collections={second.collections}
+              avatarUrl={second.avatarUrl}
+              live={second.live}
+            />
+          )}
+          {third && (
+            <CreatorCard
+              handle={third.handle}
+              exists={true}
+              score={third.score}
+              tags={third.tags}
+              collections={third.collections}
+              avatarUrl={third.avatarUrl}
+              live={third.live}
+            />
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/explorer/FeaturedHero.tsx
+++ b/frontend/src/components/explorer/FeaturedHero.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { initials, gradientStyle } from "@/lib/avatar";
+import { recordClick } from "@/lib/metrics";
+
+export default function FeaturedHero({
+  handle,
+  score,
+  avatarUrl,
+  live,
+}: {
+  handle: string;
+  score?: number;
+  avatarUrl?: string;
+  live?: boolean;
+}) {
+  return (
+    <Link
+      href={`/tip/${handle}`}
+      onClick={() => recordClick(handle, "featured")}
+      className="group relative block overflow-hidden rounded-2xl border border-white/10"
+      aria-label={`Tip @${handle}`}
+    >
+      <div className="h-40 w-full sm:h-56 md:h-64">
+        {avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={avatarUrl}
+            alt=""
+            className="h-full w-full object-cover opacity-70 transition-opacity group-hover:opacity-80"
+          />
+        ) : (
+          <div className="h-full w-full opacity-80" style={gradientStyle(handle)} />
+        )}
+      </div>
+
+      <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/10 to-transparent" />
+
+      <div className="absolute bottom-0 left-0 right-0 p-4">
+        <div className="mb-2 inline-flex items-center gap-2">
+          <span className="rounded-full border border-white/10 bg-white/10 px-2 py-0.5 text-[11px] text-white/80">
+            Featured
+          </span>
+          {typeof score === "number" && (
+            <span className="rounded-full border border-[#FFD700] bg-[#FFD700]/20 px-2 py-0.5 text-[11px] font-semibold text-[#FFD700]">
+              ★ {Math.max(0, Math.min(100, Math.round(score)))}
+            </span>
+          )}
+          {live && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-[#FF365E] px-2 py-0.5 text-[10px] font-bold text-white">
+              <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-white" /> LIVE
+            </span>
+          )}
+        </div>
+        <h3 className="text-2xl font-semibold text-white">@{handle}</h3>
+        <p className="text-sm text-white/80">Tap to send a quick tip</p>
+      </div>
+    </Link>
+  );
+}

--- a/frontend/src/components/explorer/FilterChips.tsx
+++ b/frontend/src/components/explorer/FilterChips.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+export default function FilterChips({
+  categories,
+  selected,
+  onToggle,
+}: {
+  categories: Array<{ slug: string; title: string }>;
+  selected: string[];
+  onToggle: (slug: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {categories.map((c) => {
+        const active = selected.includes(c.slug);
+        return (
+          <button
+            key={c.slug}
+            type="button"
+            onClick={() => onToggle(c.slug)}
+            className={`rounded-full px-3 py-1 text-xs font-semibold border ${
+              active
+                ? "border-[#FFD700] bg-[#FFD700]/20 text-[#FFD700]"
+                : "border-white/10 bg-white/5 text-white/80 hover:bg-white/10"
+            }`}
+            aria-pressed={active}
+          >
+            {c.title}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/explorer/SortSelect.tsx
+++ b/frontend/src/components/explorer/SortSelect.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useId } from "react";
+import type { ExplorerSort } from "@/lib/explorer";
+
+export default function SortSelect({
+  value,
+  onChange,
+}: {
+  value: ExplorerSort;
+  onChange: (v: ExplorerSort) => void;
+}) {
+  const id = useId();
+  return (
+    <label className="inline-flex items-center gap-2">
+      <span className="text-sm text-[#DDE0DA]">Sort</span>
+      <select
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value as ExplorerSort)}
+        className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-[#FFD700]"
+      >
+        <option value="trending">Trending</option>
+        <option value="newest">Newest</option>
+        <option value="az">A–Z</option>
+        <option value="za">Z–A</option>
+      </select>
+    </label>
+  );
+}

--- a/frontend/src/components/explorer/Spotlight.tsx
+++ b/frontend/src/components/explorer/Spotlight.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { initials, gradientStyle } from "@/lib/avatar";
+import { recordClick } from "@/lib/metrics";
+
+export type SpotlightItem = {
+  handle: string;
+  score?: number;
+  avatarUrl?: string;
+  live?: boolean;
+};
+
+const SEEN_KEY = "tj_spotlight_seen_v1";
+
+function getSeen(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    return JSON.parse(localStorage.getItem(SEEN_KEY) || "[]");
+  } catch {
+    return [];
+  }
+}
+function setSeen(arr: string[]) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(SEEN_KEY, JSON.stringify(arr.slice(0, 200)));
+  } catch {}
+}
+
+export default function Spotlight({ pool }: { pool: SpotlightItem[] }) {
+  const [seen, setSeenState] = useState<string[]>([]);
+  const [current, setCurrent] = useState<SpotlightItem | null>(null);
+
+  useEffect(() => {
+    setSeenState(getSeen());
+  }, []);
+
+  const candidates = useMemo(() => {
+    const s = new Set(seen);
+    const list = (pool || []).filter((it) => !s.has(it.handle));
+    return list.length ? list : pool || [];
+  }, [pool, seen]);
+
+  useEffect(() => {
+    if (!candidates.length) {
+      setCurrent(null);
+      return;
+    }
+    setCurrent(candidates[0]);
+  }, [candidates]);
+
+  function markSeen(h: string) {
+    const next = [h, ...seen.filter((x) => x !== h)];
+    setSeenState(next);
+    setSeen(next);
+  }
+
+  if (!current) return null;
+
+  const { handle, score, avatarUrl, live } = current;
+
+  return (
+    <section aria-label="Spotlight" className="space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold text-white">Spotlight</span>
+        <button
+          type="button"
+          onClick={() => {
+            markSeen(handle);
+          }}
+          className="rounded-xl border border-white/15 bg-white/5 px-3 py-1.5 text-xs text-white/80 hover:bg-white/10"
+          aria-label="Dismiss spotlight"
+        >
+          Dismiss
+        </button>
+      </div>
+
+      <Link
+        href={`/tip/${handle}`}
+        onClick={() => {
+          recordClick(handle, "spotlight");
+          markSeen(handle);
+        }}
+        className="group relative block overflow-hidden rounded-2xl border border-white/10"
+        aria-label={`Tip @${handle}`}
+      >
+        <div className="h-40 w-full sm:h-48 md:h-56">
+          {avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={avatarUrl}
+              alt=""
+              className="h-full w-full object-cover opacity-80 transition-opacity group-hover:opacity-90"
+            />
+          ) : (
+            <div className="h-full w-full opacity-90" style={gradientStyle(handle)} />
+          )}
+        </div>
+
+        <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent" />
+
+        <div className="absolute -bottom-4 left-4 grid h-16 w-16 place-items-center overflow-hidden rounded-full border border-white/10 bg-white/10 backdrop-blur">
+          <span className="text-base font-bold text-white">{initials(handle)}</span>
+        </div>
+
+        <div className="absolute bottom-0 left-24 right-4 pb-3">
+          <div className="mb-1 flex items-center gap-2">
+            <span className="rounded-full border border-white/10 bg-white/10 px-2 py-0.5 text-[11px] text-white/80">
+              Featured
+            </span>
+            {typeof score === "number" && (
+              <span className="rounded-full border border-[#FFD700] bg-[#FFD700]/20 px-2 py-0.5 text-[11px] font-semibold text-[#FFD700]">
+                ★ {Math.max(0, Math.min(100, Math.round(score)))}
+              </span>
+            )}
+            {live && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-[#FF365E] px-2 py-0.5 text-[10px] font-bold text-white">
+                <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-white" /> LIVE
+              </span>
+            )}
+          </div>
+          <h3 className="truncate text-xl font-semibold text-white">@{handle}</h3>
+          <p className="text-sm text-white/80">Tap to send a quick tip</p>
+        </div>
+      </Link>
+    </section>
+  );
+}

--- a/frontend/src/components/explorer/Suggestions.tsx
+++ b/frontend/src/components/explorer/Suggestions.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+import { recordClick } from "@/lib/metrics";
+
+export type Suggestion = { handle: string; source: "local" | "recent" };
+
+export default function Suggestions({
+  items,
+  query,
+}: {
+  items: Suggestion[];
+  query: string;
+}) {
+  if (!query || items.length === 0) return null;
+  return (
+    <div className="mt-2 rounded-xl border border-white/10 bg-white/5 p-2">
+      <p className="mb-1 px-2 text-xs text-[#BCC1B6]">Suggestions</p>
+      <ul className="divide-y divide-white/10">
+        {items.map((s) => (
+          <li key={`${s.source}:${s.handle}`}>
+            <Link
+              href={`/tip/${s.handle}`}
+              className="block px-2 py-2 text-sm text-white/90 hover:bg-white/10"
+              onClick={() => recordClick(s.handle, "suggestion")}
+            >
+              @{s.handle} <span className="text-xs text-[#BCC1B6]">({s.source})</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/explorer/TopTagsCloud.tsx
+++ b/frontend/src/components/explorer/TopTagsCloud.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+export default function TopTagsCloud({
+  items,
+  selected,
+  onToggle,
+}: {
+  items: Array<{ tag: string; count: number }>;
+  selected: string[];
+  onToggle: (tag: string) => void;
+}) {
+  if (!items?.length) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {items.map(({ tag, count }) => {
+        const active = selected.includes(tag);
+        return (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => onToggle(tag)}
+            aria-pressed={active}
+            className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+              active
+                ? "border-[#FFD700] bg-[#FFD700]/20 text-[#FFD700]"
+                : "border-white/10 bg-white/5 text-white/80 hover:bg-white/10"
+            }`}
+            title={`#${tag} • ${count}`}
+          >
+            #{tag} <span className="opacity-70">· {count}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/explorer/TrendingClient.tsx
+++ b/frontend/src/components/explorer/TrendingClient.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import TrendingNow, { type Trend } from "./TrendingNow";
+import { getRecent } from "@/lib/metrics";
+import { useMemo } from "react";
+
+export default function TrendingClient({ items }: { items: Trend[] }) {
+  const recent = getRecent(50);
+  const filtered = useMemo(
+    () => items.filter((t) => !recent.includes(t.handle)).slice(0, 12),
+    [items, recent]
+  );
+  return <TrendingNow items={filtered} />;
+}

--- a/frontend/src/components/explorer/TrendingNow.tsx
+++ b/frontend/src/components/explorer/TrendingNow.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { recordClick } from "@/lib/metrics";
+
+export type Trend = { handle: string; score?: number };
+
+export default function TrendingNow({ items }: { items: Trend[] }) {
+  if (!items?.length) return null;
+  return (
+    <section aria-label="Trending now" className="space-y-3">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-semibold text-white">Trending now</span>
+        <span aria-hidden="true" className="h-[1px] flex-1 bg-white/10" />
+      </div>
+
+      <div
+        className="no-scrollbar flex gap-2 overflow-x-auto rounded-2xl border border-white/10 bg-white/5 p-2"
+        tabIndex={0}
+      >
+        {items.map((t) => (
+          <Link
+            key={t.handle}
+            href={`/tip/${t.handle}`}
+            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-[#003737]/40 px-3 py-1.5 text-sm text-white/90 hover:bg-[#003737]/60 focus:outline-none focus:ring-2 focus:ring-[#FFD700]"
+            onClick={() => recordClick(t.handle, "trending")}
+          >
+            <span className="font-semibold">@{t.handle}</span>
+            {typeof t.score === "number" && (
+              <span className="rounded-full border border-[#FFD700] bg-[#FFD700]/20 px-2 py-0.5 text-[11px] font-semibold text-[#003737]">
+                ★ {Math.max(0, Math.min(100, Math.round(t.score)))}
+              </span>
+            )}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/explorer/YourPicks.tsx
+++ b/frontend/src/components/explorer/YourPicks.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { getTopClicked } from "@/lib/metrics";
+
+export default function YourPicks() {
+  const top = getTopClicked(12);
+  if (!top.length) return null;
+
+  return (
+    <section aria-label="Your picks" className="space-y-3">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-semibold text-white">Your picks</span>
+        <span aria-hidden className="h-[1px] flex-1 bg-white/10" />
+      </div>
+
+      <div
+        className="no-scrollbar flex gap-2 overflow-x-auto rounded-2xl border border-white/10 bg-white/5 p-2"
+        tabIndex={0}
+      >
+        {top.map(({ handle, count }) => (
+          <Link
+            key={handle}
+            href={`/tip/${handle}`}
+            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-white/90 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-[#FFD700]"
+          >
+            <span className="font-semibold">@{handle}</span>
+            <span className="rounded-full border border-white/10 bg-white/10 px-2 py-0.5 text-[11px]">
+              ×{count}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -6,7 +6,7 @@ const navItems = [
   { label: "why tipjar+?", href: "#why" },
   { label: "how it works?", href: "#how-it-works" },
   { label: "start building / ai studio", href: "#start-building" },
-  { label: "explore creators", href: "#explore" },
+  { label: "Explore", href: "/explore" },
   { label: "learn about web3", href: "#learn" },
 ];
 

--- a/frontend/src/components/public/PublicHeader.tsx
+++ b/frontend/src/components/public/PublicHeader.tsx
@@ -33,7 +33,7 @@ export default function PublicHeader() {
           <NavLink href="/why" label="Why tipjar+?" />
           <NavLink href="/how" label="How it works?" />
           <NavLink href="/ai" label="Start building / AI Studio" />
-          <NavLink href="/creators" label="Explore creators" />
+          <NavLink href="/explore" label="Explore" />
           <NavLink href="/learn" label="Learn about WEB3" />
         </div>
 

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function Card({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Page.tsx
+++ b/frontend/src/components/ui/Page.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function Page({ children }: { children: ReactNode }) {
+  return <main className="min-h-screen bg-[#001F1F] p-4">{children}</main>;
+}

--- a/frontend/src/data/collections.ts
+++ b/frontend/src/data/collections.ts
@@ -1,0 +1,35 @@
+export type HandleEntry =
+  | string
+  | {
+      handle: string;
+      score?: number;
+      tags?: string[];
+      createdAt?: string;
+      avatarUrl?: string;
+      live?: boolean;
+    };
+
+export type Collection = {
+  slug: string;
+  title: string;
+  description?: string;
+  handles: HandleEntry[];
+};
+
+export const collections: Collection[] = [
+  // przykłady (opcjonalnie):
+  // {
+  //   slug: "gaming",
+  //   title: "Gaming",
+  //   handles: [
+  //     {
+  //       handle: "pro_streamer",
+  //       score: 85,
+  //       tags: ["twitch"],
+  //       createdAt: "2025-07-01",
+  //       avatarUrl: "https://example.com/avatar.jpg",
+  //       live: true,
+  //     },
+  //   ],
+  // },
+];

--- a/frontend/src/lib/avatar.ts
+++ b/frontend/src/lib/avatar.ts
@@ -1,0 +1,19 @@
+export function initials(handle: string) {
+  const h = (handle || "").replace(/^@/, "");
+  if (!h) return "✦";
+  const parts = h.split(/[^a-z0-9]+/i).filter(Boolean);
+  const a = parts[0]?.[0] ?? "";
+  const b = parts[1]?.[0] ?? h[1] ?? "";
+  return (a + b).toUpperCase();
+}
+
+export function gradientStyle(seed: string) {
+  let x = 0;
+  for (let i = 0; i < seed.length; i++) x = (x * 31 + seed.charCodeAt(i)) >>> 0;
+  const hue = x % 360;
+  const hue2 = (hue + 40) % 360;
+  const angle = x % 180;
+  const from = `hsl(${hue} 65% 35% / .95)`;
+  const to = `hsl(${hue2} 70% 25% / .95)`;
+  return { background: `linear-gradient(${angle}deg, ${from}, ${to})` };
+}

--- a/frontend/src/lib/explorer.ts
+++ b/frontend/src/lib/explorer.ts
@@ -1,0 +1,140 @@
+export type HandleEntry =
+  | string
+  | {
+      handle: string;
+      score?: number;
+      tags?: string[];
+      createdAt?: string;
+      avatarUrl?: string;
+      live?: boolean;
+    };
+
+export type Creator = {
+  handle: string;
+  score: number;
+  tags: string[];
+  createdAt?: string;
+  collections: string[];
+  avatarUrl?: string;
+  live?: boolean;
+};
+
+export function normalizeEntry(e: HandleEntry): {
+  handle: string;
+  score: number;
+  tags: string[];
+  createdAt?: string;
+  avatarUrl?: string;
+  live?: boolean;
+} {
+  if (typeof e === "string") return { handle: e, score: 0, tags: [] };
+  return {
+    handle: e.handle,
+    score: Number(e.score ?? 0),
+    tags: e.tags ?? [],
+    createdAt: e.createdAt,
+    avatarUrl: e.avatarUrl,
+    live: e.live,
+  };
+}
+
+export function flattenCollections(
+  input: Array<{ slug: string; handles: HandleEntry[] }>
+): Creator[] {
+  const map = new Map<string, Creator>();
+  for (const col of input || []) {
+    for (const raw of col.handles || []) {
+      const n = normalizeEntry(raw);
+      const prev = map.get(n.handle);
+      if (!prev) {
+        map.set(n.handle, {
+          handle: n.handle,
+          score: n.score,
+          tags: n.tags,
+          createdAt: n.createdAt,
+          avatarUrl: n.avatarUrl,
+          live: n.live,
+          collections: [col.slug],
+        });
+      } else {
+        prev.score = Math.max(prev.score, n.score);
+        prev.tags = Array.from(new Set([...prev.tags, ...n.tags]));
+        if (!prev.avatarUrl && n.avatarUrl) prev.avatarUrl = n.avatarUrl;
+        if (n.live) prev.live = true;
+        if (!prev.collections.includes(col.slug)) prev.collections.push(col.slug);
+      }
+    }
+  }
+  return Array.from(map.values());
+}
+
+export type ExplorerFilters = {
+  query?: string;
+  categories?: string[];
+  tags?: string[];
+};
+
+export function applyQuery(rows: Creator[], q?: string): Creator[] {
+  const s = (q ?? "").trim().toLowerCase();
+  if (!s) return rows;
+  return rows.filter((r) => r.handle.toLowerCase().includes(s));
+}
+
+export function applyFilters(rows: Creator[], f: ExplorerFilters): Creator[] {
+  let out = rows;
+  if (f?.categories?.length) {
+    const want = new Set(f.categories);
+    out = out.filter((r) => r.collections.some((c) => want.has(c)));
+  }
+  if (f?.tags?.length) {
+    const wantTags = new Set(f.tags.map((t) => t.toLowerCase()));
+    out = out.filter((r) => r.tags?.some((t) => wantTags.has(String(t).toLowerCase())));
+  }
+  return applyQuery(out, f.query);
+}
+
+export type ExplorerSort = "trending" | "newest" | "az" | "za";
+
+export function sortCreators(rows: Creator[], mode: ExplorerSort): Creator[] {
+  const copy = [...rows];
+  switch (mode) {
+    case "newest":
+      return copy.sort((a, b) => {
+        const A = a.createdAt ? Date.parse(a.createdAt) : 0;
+        const B = b.createdAt ? Date.parse(b.createdAt) : 0;
+        return B - A || a.handle.localeCompare(b.handle);
+      });
+    case "az":
+      return copy.sort((a, b) => a.handle.localeCompare(b.handle));
+    case "za":
+      return copy.sort((a, b) => b.handle.localeCompare(a.handle));
+    case "trending":
+    default:
+      return copy.sort((a, b) => b.score - a.score || a.handle.localeCompare(b.handle));
+  }
+}
+
+export function paginate<T>(rows: T[], page: number, perPage: number) {
+  const start = (page - 1) * perPage;
+  const items = rows.slice(start, start + perPage);
+  return { items, total: rows.length, hasMore: start + items.length < rows.length };
+}
+
+export function topTags(
+  rows: Creator[],
+  limit = 16
+): Array<{ tag: string; count: number }> {
+  const m = new Map<string, number>();
+  for (const r of rows) for (const t of r.tags || []) {
+    const k = String(t).toLowerCase();
+    m.set(k, (m.get(k) || 0) + 1);
+  }
+  return Array.from(m.entries())
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+    .slice(0, limit);
+}
+
+function uniq<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr));
+}

--- a/frontend/src/lib/metrics.ts
+++ b/frontend/src/lib/metrics.ts
@@ -1,0 +1,44 @@
+const RECENT_KEY = "tj_recent_searches";
+const CLICKS_KEY = "tj_clicks";
+
+type Clicks = Record<string, number>;
+
+function safeGet<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    return JSON.parse(localStorage.getItem(key) || "") as T;
+  } catch {
+    return fallback;
+  }
+}
+function safeSet<T>(key: string, value: T) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {}
+}
+
+export function recordClick(handle: string, _ctx: string = "tip") {
+  if (!handle) return;
+  const clicks = safeGet<Clicks>(CLICKS_KEY, {});
+  clicks[handle] = (clicks[handle] || 0) + 1;
+  safeSet(CLICKS_KEY, clicks);
+  const recent = getRecentRaw();
+  const next = [handle, ...recent.filter((h) => h !== handle)].slice(0, 30);
+  safeSet(RECENT_KEY, next);
+}
+
+export function getRecent(limit = 10): string[] {
+  return getRecentRaw().slice(0, limit);
+}
+function getRecentRaw(): string[] {
+  return safeGet<string[]>(RECENT_KEY, []);
+}
+
+export function getTopClicked(limit = 12): Array<{ handle: string; count: number }> {
+  const clicks = safeGet<Clicks>(CLICKS_KEY, {});
+  return Object.entries(clicks)
+    .map(([handle, count]) => ({ handle, count }))
+    .sort((a, b) => b.count - a.count || a.handle.localeCompare(b.handle))
+    .slice(0, limit);
+}

--- a/frontend/tests/e2e/specs/explorer-ui.spec.ts
+++ b/frontend/tests/e2e/specs/explorer-ui.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("explorer ui", () => {
+  test("loads /explore and shows heading", async ({ page }) => {
+    await page.goto("/explore");
+    await expect(page.getByRole("heading", { name: /discover creators/i })).toBeVisible();
+  });
+
+  test("loads /discover as well", async ({ page }) => {
+    await page.goto("/discover");
+    await expect(page.getByRole("heading", { name: /discover creators/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Explorer alias route with rich metadata
- implement client-only Spotlight and featured sections for Discover/Explore
- link new Explore route from nav and footer

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8f2a7bd48327965d8934f291e162