### PR TITLE
fix: place use client directive at top of discover page

### DIFF
--- a/frontend/src/app/discover/metadata.ts
+++ b/frontend/src/app/discover/metadata.ts
@@ -1,0 +1,4 @@
+export const metadata = {
+  title: "Discover — tipjar+",
+  alternates: { canonical: "/discover" },
+};

--- a/frontend/src/app/discover/page.tsx
+++ b/frontend/src/app/discover/page.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Page from "@/components/ui/Page";
 import Card from "@/components/ui/Card";
 import SearchBox, { type SearchResult } from "@/components/discover/SearchBox";
@@ -6,11 +9,12 @@ import { collections } from "@/data/collections";
 import CollectionCard from "@/components/explorer/CollectionCard";
 import SortSelect from "@/components/explorer/SortSelect";
 import FilterChips from "@/components/explorer/FilterChips";
-import Suggestions from "@/components/explorer/Suggestions";
+import Suggestions, { type Suggestion } from "@/components/explorer/Suggestions";
 import TrendingClient from "@/components/explorer/TrendingClient";
 import YourPicks from "@/components/explorer/YourPicks";
 import FeaturedGrid from "@/components/explorer/FeaturedGrid";
 import Spotlight from "@/components/explorer/Spotlight";
+import TopTagsCloud from "@/components/explorer/TopTagsCloud";
 import {
   flattenCollections,
   applyFilters,
@@ -19,11 +23,6 @@ import {
   type ExplorerSort,
   topTags,
 } from "@/lib/explorer";
-
-export const metadata = {
-  title: "Discover — tipjar+",
-  alternates: { canonical: "/discover" },
-};
 
 export default function PageDiscover() {
   const items: SearchResult[] = [];
@@ -92,11 +91,6 @@ export default function PageDiscover() {
   );
 }
 
-"use client";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import TopTagsCloud from "@/components/explorer/TopTagsCloud";
-import type { Suggestion } from "@/components/explorer/Suggestions";
-import { collections as D } from "@/data/collections";
 
 function Client({ initial }: { initial: SearchResult[] }) {
   const [direct, setDirect] = useState<SearchResult[]>(initial);
@@ -224,7 +218,7 @@ function useSuggestions(q: string): Suggestion[] {
   if (s.length < 2) return [];
   const fromLocal = Array.from(
     new Set(
-      (D || [])
+      (collections || [])
         .flatMap((c) => (c.handles || []).map((h: any) => (typeof h === "string" ? h : h.handle)))
         .filter(Boolean)
     )


### PR DESCRIPTION
## Summary
- move `"use client"` to top of `discover/page.tsx`
- extract `metadata` to separate server file

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c0a0ffb4832781631eb099afef5c