### PR TITLE
fix(frontend): allow metadata on onboarding steps

### DIFF
--- a/frontend/src/app/onboarding/notifications/page.tsx
+++ b/frontend/src/app/onboarding/notifications/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-import { useRouter } from "next/navigation";
-import OnboardingShell from "@/components/onboarding/OnboardingShell";
-import { useState } from "react";
-import OnboardingGuard from "@/components/onboarding/OnboardingGuard";
+import NotificationsStep from "@/components/onboarding/NotificationsStep";
 
 export const metadata = {
   title: "Onboarding — notifications • tipjar+",
@@ -11,66 +7,5 @@ export const metadata = {
 };
 
 export default function Page() {
-  const router = useRouter();
-  const [prefs, setPrefs] = useState({
-    emailTips: true,
-    followers: true,
-    productUpdates: false,
-    hideSupporters: false,
-  });
-  function toggle<K extends keyof typeof prefs>(k: K) {
-    setPrefs((p) => ({ ...p, [k]: !p[k] }));
-  }
-  return (
-    <OnboardingGuard>
-      <OnboardingShell title="Notifications & privacy" step={4}>
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <Switch label="Email tips" checked={prefs.emailTips} onChange={() => toggle("emailTips")} />
-            <Switch label="New followers" checked={prefs.followers} onChange={() => toggle("followers")} />
-            <Switch label="Product updates" checked={prefs.productUpdates} onChange={() => toggle("productUpdates")} />
-            <Switch label="Privacy: hide my supporters" checked={prefs.hideSupporters} onChange={() => toggle("hideSupporters")} />
-          </div>
-          <p className="mt-3 text-xs text-[#BCC1B6]">
-            Ustawienia zapiszesz później w profilu — tu tylko preferencje startowe (UI).
-          </p>
-        </div>
-        <div className="mt-6 flex gap-3">
-          <button onClick={() => router.back()} className="rounded-xl border border-white/15 px-4 py-3 text-white/80">
-            Back
-          </button>
-          <button
-            onClick={() => router.push("/onboarding/done")}
-            className="rounded-xl bg-[#FFD700] px-4 py-3 font-semibold text-[#003737]"
-          >
-            Finish
-          </button>
-        </div>
-      </OnboardingShell>
-    </OnboardingGuard>
-  );
+  return <NotificationsStep />;
 }
-
-function Switch({ label, checked, onChange }: { label: string; checked: boolean; onChange: () => void }) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      onClick={onChange}
-      className={`flex w-full items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/5 p-4 ${
-        checked ? "ring-2 ring-[#FFD700]" : ""
-      }`}
-    >
-      <span className="text-sm text-white/90">{label}</span>
-      <span aria-hidden="true" className={`relative h-5 w-10 rounded-full ${checked ? "bg-[#FFD700]" : "bg-white/20"}`}>
-        <span
-          className={`absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full bg-white transition-transform ${
-            checked ? "translate-x-5" : "translate-x-1"
-          }`}
-        />
-      </span>
-    </button>
-  );
-}
-

--- a/frontend/src/app/onboarding/profile/page.tsx
+++ b/frontend/src/app/onboarding/profile/page.tsx
@@ -1,9 +1,4 @@
-"use client";
-import { useRouter } from "next/navigation";
-import OnboardingShell from "@/components/onboarding/OnboardingShell";
-import ProfileForm from "@/components/onboarding/ProfileForm";
-import { useState } from "react";
-import OnboardingGuard from "@/components/onboarding/OnboardingGuard";
+import ProfileStep from "@/components/onboarding/ProfileStep";
 
 export const metadata = {
   title: "Onboarding — profile • tipjar+",
@@ -12,41 +7,5 @@ export const metadata = {
 };
 
 export default function Page() {
-  const router = useRouter();
-  const [form, setForm] = useState<
-    { displayName: string; language: string; bio: string } | null
-  >(null);
-  const valid =
-    !!form &&
-    (form.displayName?.trim() ?? "").length > 0 &&
-    (form.displayName?.trim() ?? "").length <= 60 &&
-    (form.bio?.trim() ?? "").length > 0 &&
-    (form.bio?.trim() ?? "").length <= 280;
-
-  return (
-    <OnboardingGuard>
-      <OnboardingShell title="Complete your profile" step={3}>
-        <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
-          <ProfileForm onChange={setForm} />
-        </div>
-        <div className="mt-6 flex gap-3">
-          <button
-            onClick={() => router.back()}
-            className="rounded-xl border border-white/15 px-4 py-3 text-white/80"
-          >
-            Back
-          </button>
-          <button
-            disabled={!valid}
-            onClick={() => router.push("/onboarding/notifications")}
-            className="rounded-xl bg-[#FFD700] px-4 py-3 font-semibold text-[#003737] disabled:opacity-60"
-            aria-disabled={!valid}
-          >
-            Continue
-          </button>
-        </div>
-      </OnboardingShell>
-    </OnboardingGuard>
-  );
+  return <ProfileStep />;
 }
-

--- a/frontend/src/app/onboarding/username/page.tsx
+++ b/frontend/src/app/onboarding/username/page.tsx
@@ -1,10 +1,4 @@
-"use client";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-import OnboardingShell from "@/components/onboarding/OnboardingShell";
-import UsernameForm from "@/components/onboarding/UsernameForm";
-import { setUsername } from "@/lib/users";
-import OnboardingGuard from "@/components/onboarding/OnboardingGuard";
+import UsernameStep from "@/components/onboarding/UsernameStep";
 
 export const metadata = {
   title: "Onboarding — username • tipjar+",
@@ -13,47 +7,5 @@ export const metadata = {
 };
 
 export default function Page() {
-  const router = useRouter();
-  const [reserved, setReserved] = useState<string | null>(null);
-  const [busy, setBusy] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-
-  async function onContinue() {
-    if (!reserved) return;
-    setBusy(true);
-    setErr(null);
-    try {
-      await setUsername(reserved);
-      router.push("/onboarding/wallet");
-    } catch (e: any) {
-      setErr(e?.message || "Could not reserve username");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <OnboardingGuard>
-      <OnboardingShell title="Welcome — pick your @handle" step={1}>
-        <UsernameForm onValid={setReserved} />
-        {err && <p className="mt-3 text-sm text-red-300">{err}</p>}
-        <div className="mt-6 flex gap-3">
-          <button
-            disabled={!reserved || busy}
-            onClick={onContinue}
-            className="rounded-xl bg-[#FFD700] px-4 py-3 font-semibold text-[#003737] disabled:opacity-60"
-          >
-            {busy ? "Saving…" : "Continue"}
-          </button>
-          <button
-            onClick={() => router.push("/")}
-            className="rounded-xl border border-white/15 px-4 py-3 text-white/80"
-          >
-            Exit
-          </button>
-        </div>
-      </OnboardingShell>
-    </OnboardingGuard>
-  );
+  return <UsernameStep />;
 }
-

--- a/frontend/src/app/onboarding/wallet/page.tsx
+++ b/frontend/src/app/onboarding/wallet/page.tsx
@@ -1,7 +1,4 @@
-"use client";
-import OnboardingShell from "@/components/onboarding/OnboardingShell";
-import WalletConnect from "@/components/onboarding/WalletConnect";
-import OnboardingGuard from "@/components/onboarding/OnboardingGuard";
+import WalletStep from "@/components/onboarding/WalletStep";
 
 export const metadata = {
   title: "Onboarding — wallet • tipjar+",
@@ -10,12 +7,5 @@ export const metadata = {
 };
 
 export default function Page() {
-  return (
-    <OnboardingGuard>
-      <OnboardingShell title="Connect your wallet" step={2}>
-        <WalletConnect />
-      </OnboardingShell>
-    </OnboardingGuard>
-  );
+  return <WalletStep />;
 }
-

--- a/frontend/src/components/onboarding/NotificationsStep.tsx
+++ b/frontend/src/components/onboarding/NotificationsStep.tsx
@@ -1,0 +1,69 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import OnboardingShell from "@/components/onboarding/OnboardingShell";
+import OnboardingGuard from "@/components/onboarding/OnboardingGuard";
+
+export default function NotificationsStep() {
+  const router = useRouter();
+  const [prefs, setPrefs] = useState({
+    emailTips: true,
+    followers: true,
+    productUpdates: false,
+    hideSupporters: false,
+  });
+  function toggle<K extends keyof typeof prefs>(k: K) {
+    setPrefs((p) => ({ ...p, [k]: !p[k] }));
+  }
+  return (
+    <OnboardingGuard>
+      <OnboardingShell title="Notifications & privacy" step={4}>
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <Switch label="Email tips" checked={prefs.emailTips} onChange={() => toggle("emailTips")} />
+            <Switch label="New followers" checked={prefs.followers} onChange={() => toggle("followers")} />
+            <Switch label="Product updates" checked={prefs.productUpdates} onChange={() => toggle("productUpdates")} />
+            <Switch label="Privacy: hide my supporters" checked={prefs.hideSupporters} onChange={() => toggle("hideSupporters")} />
+          </div>
+          <p className="mt-3 text-xs text-[#BCC1B6]">
+            Ustawienia zapiszesz później w profilu — tu tylko preferencje startowe (UI).
+          </p>
+        </div>
+        <div className="mt-6 flex gap-3">
+          <button onClick={() => router.back()} className="rounded-xl border border-white/15 px-4 py-3 text-white/80">
+            Back
+          </button>
+          <button
+            onClick={() => router.push("/onboarding/done")}
+            className="rounded-xl bg-[#FFD700] px-4 py-3 font-semibold text-[#003737]"
+          >
+            Finish
+          </button>
+        </div>
+      </OnboardingShell>
+    </OnboardingGuard>
+  );
+}
+
+function Switch({ label, checked, onChange }: { label: string; checked: boolean; onChange: () => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={onChange}
+      className={`flex w-full items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/5 p-4 ${
+        checked ? "ring-2 ring-[#FFD700]" : ""
+      }`}
+    >
+      <span className="text-sm text-white/90">{label}</span>
+      <span aria-hidden="true" className={`relative h-5 w-10 rounded-full ${checked ? "bg-[#FFD700]" : "bg-white/20"}`}>
+        <span
+          className={`absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full bg-white transition-transform ${
+            checked ? "translate-x-5" : "translate-x-1"
+          }`}
+        />
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/components/onboarding/ProfileStep.tsx
+++ b/frontend/src/components/onboarding/ProfileStep.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import OnboardingShell from "@/components/onboarding/OnboardingShell";
+import ProfileForm from "@/components/onboarding/ProfileForm";
+import OnboardingGuard from "@/components/onboarding/OnboardingGuard";
+
+export default function ProfileStep() {
+  const router = useRouter();
+  const [form, setForm] = useState<
+    { displayName: string; language: string; bio: string } | null
+  >(null);
+  const valid =
+    !!form &&
+    (form.displayName?.trim() ?? "").length > 0 &&
+    (form.displayName?.trim() ?? "").length <= 60 &&
+    (form.bio?.trim() ?? "").length > 0 &&
+    (form.bio?.trim() ?? "").length <= 280;
+
+  return (
+    <OnboardingGuard>
+      <OnboardingShell title="Complete your profile" step={3}>
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-5">
+          <ProfileForm onChange={setForm} />
+        </div>
+        <div className="mt-6 flex gap-3">
+          <button
+            onClick={() => router.back()}
+            className="rounded-xl border border-white/15 px-4 py-3 text-white/80"
+          >
+            Back
+          </button>
+          <button
+            disabled={!valid}
+            onClick={() => router.push("/onboarding/notifications")}
+            className="rounded-xl bg-[#FFD700] px-4 py-3 font-semibold text-[#003737] disabled:opacity-60"
+            aria-disabled={!valid}
+          >
+            Continue
+          </button>
+        </div>
+      </OnboardingShell>
+    </OnboardingGuard>
+  );
+}

--- a/frontend/src/components/onboarding/UsernameStep.tsx
+++ b/frontend/src/components/onboarding/UsernameStep.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import OnboardingShell from "@/components/onboarding/OnboardingShell";
+import UsernameForm from "@/components/onboarding/UsernameForm";
+import { setUsername } from "@/lib/users";
+import OnboardingGuard from "@/components/onboarding/OnboardingGuard";
+
+export default function UsernameStep() {
+  const router = useRouter();
+  const [reserved, setReserved] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function onContinue() {
+    if (!reserved) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      await setUsername(reserved);
+      router.push("/onboarding/wallet");
+    } catch (e: any) {
+      setErr(e?.message || "Could not reserve username");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <OnboardingGuard>
+      <OnboardingShell title="Welcome — pick your @handle" step={1}>
+        <UsernameForm onValid={setReserved} />
+        {err && <p className="mt-3 text-sm text-red-300">{err}</p>}
+        <div className="mt-6 flex gap-3">
+          <button
+            disabled={!reserved || busy}
+            onClick={onContinue}
+            className="rounded-xl bg-[#FFD700] px-4 py-3 font-semibold text-[#003737] disabled:opacity-60"
+          >
+            {busy ? "Saving…" : "Continue"}
+          </button>
+          <button
+            onClick={() => router.push("/")}
+            className="rounded-xl border border-white/15 px-4 py-3 text-white/80"
+          >
+            Exit
+          </button>
+        </div>
+      </OnboardingShell>
+    </OnboardingGuard>
+  );
+}

--- a/frontend/src/components/onboarding/WalletStep.tsx
+++ b/frontend/src/components/onboarding/WalletStep.tsx
@@ -1,0 +1,14 @@
+"use client";
+import OnboardingShell from "@/components/onboarding/OnboardingShell";
+import WalletConnect from "@/components/onboarding/WalletConnect";
+import OnboardingGuard from "@/components/onboarding/OnboardingGuard";
+
+export default function WalletStep() {
+  return (
+    <OnboardingGuard>
+      <OnboardingShell title="Connect your wallet" step={2}>
+        <WalletConnect />
+      </OnboardingShell>
+    </OnboardingGuard>
+  );
+}


### PR DESCRIPTION
## Summary
- split onboarding username, profile, wallet and notifications pages into server wrappers and client steps
- keep metadata export without `use client`

## Testing
- `npm install`
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore"; Unexpected any, etc.)*
- `npm run build` *(fails: Failed to fetch font file from fonts.gstatic.com)*
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run npx playwright install)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c5913794832798505c3e0676a604