### PR TITLE
feat(frontend): add learn and creator profile pages

### DIFF
--- a/frontend/src/app/creators/[alias]/page.tsx
+++ b/frontend/src/app/creators/[alias]/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next';
+import Page from '@/components/ui/Page';
+import Card from '@/components/ui/Card';
+import TipLauncher from '@/components/TipLauncher';
+
+interface PageProps {
+  params: { alias: string };
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { alias } = params;
+  return {
+    title: `@${alias} — tipjar+`,
+    description: `Profil twórcy @${alias}.`,
+    alternates: { canonical: `/creators/${alias}` },
+    robots: { index: true, follow: true },
+  };
+}
+
+export default function CreatorProfilePage({ params }: PageProps) {
+  const { alias } = params;
+  return (
+    <Page>
+      <article className="mx-auto max-w-3xl space-y-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-bold text-white">@{alias}</h1>
+          <p className="text-[#DDE0DA]">
+            Publiczny profil twórcy. Wyślij napiwek, aby okazać wsparcie.
+          </p>
+        </header>
+        <Card>
+          <TipLauncher username={alias} />
+        </Card>
+      </article>
+    </Page>
+  );
+}
+

--- a/frontend/src/app/learn/page.tsx
+++ b/frontend/src/app/learn/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from 'next';
+import Page from '@/components/ui/Page';
+import Card from '@/components/ui/Card';
+
+export const metadata: Metadata = {
+  title: 'Learn — tipjar+',
+  description: 'Centrum wiedzy o kryptowalutach i tipowaniu w USDC.',
+  alternates: { canonical: '/learn' },
+  robots: { index: true, follow: true },
+};
+
+const articles = [
+  { title: 'Jak kupić USDC?' },
+  { title: 'Polecane portfele' },
+  { title: 'Czy to bezpieczne?' },
+];
+
+export default function LearnPage() {
+  return (
+    <Page>
+      <div className="mx-auto max-w-3xl space-y-6">
+        <header className="space-y-2">
+          <h1 className="text-2xl font-bold text-white">Centrum wiedzy</h1>
+          <p className="text-[#DDE0DA]">Dowiedz się, jak zacząć korzystać z kryptowalut w TipJar.</p>
+        </header>
+        <ul className="space-y-4">
+          {articles.map(({ title }) => (
+            <li key={title}>
+              <Card>
+                <p className="text-lg font-medium text-[#FFD700]">{title}</p>
+              </Card>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Page>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add public creator profile route with tip launcher
- introduce static learn page with article links

## Testing
- `npm test` *(fails: Host system is missing dependencies to run browsers)*
- `npm run lint` *(fails: lint errors across existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c5c6a60883278055278dd9d4e287