### PR TITLE
feat(frontend): add fan and creator dashboard skeleton

### DIFF
--- a/frontend/src/app/dashboard/goal/page.tsx
+++ b/frontend/src/app/dashboard/goal/page.tsx
@@ -1,0 +1,10 @@
+import GoalForm from '@/components/dashboard/GoalForm';
+
+export default function GoalPage() {
+  return (
+    <div className="max-w-xl">
+      <h1 className="text-2xl font-semibold mb-4">Cel finansowy</h1>
+      <GoalForm initial={{ title: 'Nowy mikrofon', target: 500, deadline: '' }} onSubmit={async () => {}} />
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -1,0 +1,23 @@
+import Sidebar from '@/components/ui/Sidebar';
+import HeaderBar from '@/components/ui/HeaderBar';
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const items = [
+    { href: '/dashboard', label: 'Pulpit' },
+    { href: '/dashboard/profile', label: 'Profil' },
+    { href: '/dashboard/withdrawals', label: 'Wypłaty' },
+    { href: '/dashboard/goal', label: 'Cel' },
+    { href: '/dashboard/subscriptions', label: 'Subskrypcje' },
+  ];
+  return (
+    <div className="min-h-screen grid grid-cols-[240px_1fr] bg-[var(--surface-2)] text-[var(--fg)]">
+      <aside className="border-r border-white/10">
+        <Sidebar items={items} />
+      </aside>
+      <div className="min-h-screen">
+        <HeaderBar title="Panel twórcy" />
+        <main className="p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,24 @@
+import TipStatistics from '@/components/dashboard/TipStatistics';
+
+export default async function DashboardPage() {
+  const series = [2, 3, 1, 5, 4, 6, 8, 5, 7, 9, 11, 10];
+  const total = 1245;
+  const fans = 86;
+  const lastTips = [{ fan: 'aga42', amount: 5, time: '2h' }];
+
+  return (
+    <div className="space-y-6">
+      <TipStatistics series={series} total={total} fans={fans} />
+      <section>
+        <h2 className="text-xl font-semibold">Ostatnie napiwki</h2>
+        <div className="mt-3 grid gap-2">
+          {lastTips.map((t, i) => (
+            <div key={i} className="rounded-xl bg-white/5 border border-white/10 p-3">
+              <span className="font-semibold">{t.fan}</span> • {t.amount} USDC • {t.time} temu
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/profile/page.tsx
+++ b/frontend/src/app/dashboard/profile/page.tsx
@@ -1,0 +1,17 @@
+import ProfileForm from '@/components/dashboard/ProfileForm';
+
+export default function ProfileSettingsPage() {
+  const initial = {
+    name: '',
+    alias: '',
+    bio: '',
+    links: { youtube: '', twitch: '' },
+    goal: { target: 500, current: 120 },
+  };
+  return (
+    <div className="max-w-2xl">
+      <h1 className="text-2xl font-semibold mb-4">Ustawienia profilu</h1>
+      <ProfileForm initial={initial} onSubmit={async () => {}} />
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/subscriptions/page.tsx
+++ b/frontend/src/app/dashboard/subscriptions/page.tsx
@@ -1,0 +1,11 @@
+import SubscriptionsList from '@/components/dashboard/SubscriptionsList';
+
+export default function SubscriptionsPage() {
+  const items = [{ fan: 'neo77', amount: 5, period: 'mies.' }];
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold mb-4">Subskrypcje</h1>
+      <SubscriptionsList items={items} />
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/withdrawals/page.tsx
+++ b/frontend/src/app/dashboard/withdrawals/page.tsx
@@ -1,0 +1,10 @@
+import WithdrawalForm from '@/components/dashboard/WithdrawalForm';
+
+export default function WithdrawalsPage() {
+  return (
+    <div className="max-w-lg">
+      <h1 className="text-2xl font-semibold mb-4">Wypłaty</h1>
+      <WithdrawalForm balance={342.5} onSubmit={async () => {}} />
+    </div>
+  );
+}

--- a/frontend/src/app/feed/page.tsx
+++ b/frontend/src/app/feed/page.tsx
@@ -1,0 +1,17 @@
+export default function FeedPage() {
+  const items = [{ type: 'tip_thanks', creator: 'marta_art', amount: 5, time: '1d' }];
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h1 className="text-2xl font-semibold mb-4">Twoja aktywność</h1>
+      <div className="grid gap-2">
+        {items.map((x, i) => (
+          <div key={i} className="rounded-xl bg-white/5 border border-white/10 p-3">
+            {x.type === 'tip_thanks' ? (
+              <>Twórca <b>{x.creator}</b> podziękował za {x.amount} USDC • {x.time}</>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/following/page.tsx
+++ b/frontend/src/app/following/page.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function FollowingPage() {
+  const creators = [{ alias: 'aga_music', name: 'Aga' }];
+  return (
+    <div className="max-w-3xl">
+      <h1 className="text-2xl font-semibold mb-4">Obserwowani</h1>
+      <div className="grid gap-3">
+        {creators.map((c) => (
+          <Link
+            key={c.alias}
+            href={`/creators/${c.alias}`}
+            className="rounded-xl bg-white/5 border border-white/10 p-4 hover:border-primary/50"
+          >
+            <div className="font-semibold">{c.name}</div>
+            <div className="text-sm opacity-75">@{c.alias}</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/notifications/page.tsx
+++ b/frontend/src/app/notifications/page.tsx
@@ -1,0 +1,18 @@
+export default function NotificationsPage() {
+  const items = [{ id: 1, text: 'Nowy post od @aga_music', unread: true }];
+  return (
+    <div className="max-w-2xl">
+      <h1 className="text-2xl font-semibold mb-4">Powiadomienia</h1>
+      <div className="grid gap-2">
+        {items.map((n) => (
+          <div
+            key={n.id}
+            className={`rounded-xl border p-3 ${n.unread ? 'bg-primary/10 border-primary/30' : 'bg-white/5 border-white/10'}`}
+          >
+            {n.text}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,0 +1,18 @@
+export default function SettingsPage() {
+  return (
+    <div className="max-w-xl">
+      <h1 className="text-2xl font-semibold mb-4">Ustawienia</h1>
+      <form className="grid gap-3">
+        <label className="grid gap-1">
+          <span className="text-sm opacity-80">E-mail</span>
+          <input className="rounded-lg bg-white/5 border border-white/10 p-2" placeholder="you@example.com" />
+        </label>
+        <label className="grid gap-1">
+          <span className="text-sm opacity-80">Nowe hasło</span>
+          <input type="password" className="rounded-lg bg-white/5 border border-white/10 p-2" />
+        </label>
+        <button className="rounded-lg bg-primary text-black font-semibold px-4 py-2">Zapisz</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/app/wallet/page.tsx
+++ b/frontend/src/app/wallet/page.tsx
@@ -1,0 +1,29 @@
+export default function WalletPage() {
+  const balance = 42.75;
+  const tx = [
+    { id: 'tx1', kind: 'tip', amount: -5, ts: '2025-08-20' },
+    { id: 'tx2', kind: 'deposit', amount: 50, ts: '2025-08-18' },
+  ];
+  return (
+    <div className="max-w-2xl">
+      <h1 className="text-2xl font-semibold mb-4">Portfel</h1>
+      <div className="rounded-xl bg-white/5 border border-white/10 p-4 mb-6">
+        <div className="text-sm opacity-80">Saldo</div>
+        <div className="text-3xl font-bold">{balance.toFixed(2)} USDC</div>
+      </div>
+      <h2 className="text-xl font-semibold mb-2">Historia</h2>
+      <div className="grid gap-2">
+        {tx.map((t) => (
+          <div key={t.id} className="rounded-xl bg-white/5 border border-white/10 p-3 flex justify-between">
+            <span className="capitalize">{t.kind}</span>
+            <span className={t.amount < 0 ? 'text-red-300' : 'text-green-300'}>
+              {t.amount > 0 ? '+' : ''}
+              {t.amount} USDC
+            </span>
+            <span className="opacity-70">{t.ts}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/GoalForm.tsx
+++ b/frontend/src/components/dashboard/GoalForm.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { useState } from 'react';
+
+export type Goal = { title: string; target: number; deadline?: string };
+
+export default function GoalForm({
+  initial,
+  onSubmit,
+}: {
+  initial?: Goal;
+  onSubmit: (v: Goal) => Promise<void> | void;
+}) {
+  const [v, setV] = useState<Goal>(initial ?? { title: '', target: 0, deadline: '' });
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        await onSubmit(v);
+      }}
+      className="grid gap-3"
+    >
+      <input
+        className="rounded-lg bg-white/5 border border-white/10 p-2"
+        placeholder="Tytuł"
+        value={v.title}
+        onChange={(e) => setV((s) => ({ ...s, title: e.target.value }))}
+      />
+      <input
+        type="number"
+        min={0}
+        className="rounded-lg bg-white/5 border border-white/10 p-2"
+        placeholder="Kwota docelowa (USDC)"
+        value={v.target}
+        onChange={(e) => setV((s) => ({ ...s, target: Number(e.target.value || 0) }))}
+      />
+      <input
+        type="date"
+        className="rounded-lg bg-white/5 border border-white/10 p-2"
+        value={v.deadline}
+        onChange={(e) => setV((s) => ({ ...s, deadline: e.target.value }))}
+      />
+      <button className="rounded-lg bg-[var(--color-primary)] text-black font-semibold px-4 py-2">
+        Zapisz cel
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/dashboard/ProfileForm.tsx
+++ b/frontend/src/components/dashboard/ProfileForm.tsx
@@ -1,0 +1,109 @@
+"use client";
+import { useState } from 'react';
+
+export type CreatorProfile = {
+  name: string;
+  alias: string;
+  bio: string;
+  links?: { youtube?: string; twitch?: string; twitter?: string };
+  goal?: { target: number; current?: number };
+};
+
+export default function ProfileForm({
+  initial,
+  onSubmit,
+}: {
+  initial?: CreatorProfile;
+  onSubmit: (v: CreatorProfile) => Promise<void> | void;
+}) {
+  const [v, setV] = useState<CreatorProfile>(initial ?? { name: '', alias: '', bio: '' });
+  const [saving, setSaving] = useState(false);
+  const change = (k: keyof CreatorProfile, val: any) => setV((s) => ({ ...s, [k]: val }));
+
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        setSaving(true);
+        await onSubmit(v);
+        setSaving(false);
+      }}
+      className="grid gap-3"
+    >
+      <label className="grid gap-1">
+        <span className="text-sm opacity-80">Nazwa</span>
+        <input
+          required
+          value={v.name}
+          onChange={(e) => change('name', e.target.value)}
+          className="rounded-lg bg-white/5 border border-white/10 p-2"
+        />
+      </label>
+      <label className="grid gap-1">
+        <span className="text-sm opacity-80">Alias</span>
+        <input
+          required
+          value={v.alias}
+          onChange={(e) => change('alias', e.target.value)}
+          className="rounded-lg bg-white/5 border border-white/10 p-2"
+        />
+      </label>
+      <label className="grid gap-1">
+        <span className="text-sm opacity-80">Bio</span>
+        <textarea
+          value={v.bio}
+          onChange={(e) => change('bio', e.target.value)}
+          className="rounded-lg bg-white/5 border border-white/10 p-2 min-h-[120px]"
+        />
+      </label>
+
+      <fieldset className="grid sm:grid-cols-2 gap-3 p-3 rounded-xl border border-white/10">
+        <legend className="px-2 text-sm opacity-80">Linki</legend>
+        <input
+          placeholder="YouTube URL"
+          value={v.links?.youtube ?? ''}
+          onChange={(e) => setV((s) => ({ ...s, links: { ...s.links, youtube: e.target.value } }))}
+          className="rounded-lg bg-white/5 border border-white/10 p-2"
+        />
+        <input
+          placeholder="Twitch URL"
+          value={v.links?.twitch ?? ''}
+          onChange={(e) => setV((s) => ({ ...s, links: { ...s.links, twitch: e.target.value } }))}
+          className="rounded-lg bg-white/5 border border-white/10 p-2"
+        />
+      </fieldset>
+
+      <fieldset className="grid sm:grid-cols-[1fr_1fr] gap-3 p-3 rounded-xl border border-white/10">
+        <legend className="px-2 text-sm opacity-80">Cel</legend>
+        <input
+          type="number"
+          min={0}
+          placeholder="Kwota docelowa (USDC)"
+          value={v.goal?.target ?? 0}
+          onChange={(e) =>
+            setV((s) => ({ ...s, goal: { ...s.goal, target: Number(e.target.value || 0) } }))
+          }
+          className="rounded-lg bg-white/5 border border-white/10 p-2"
+        />
+        <input
+          type="number"
+          min={0}
+          placeholder="Obecny postęp"
+          value={v.goal?.current ?? 0}
+          onChange={(e) =>
+            setV((s) => ({ ...s, goal: { ...s.goal, current: Number(e.target.value || 0) } }))
+          }
+          className="rounded-lg bg-white/5 border border-white/10 p-2"
+        />
+      </fieldset>
+
+      <button
+        disabled={saving}
+        aria-busy={saving}
+        className="rounded-lg bg-[var(--color-primary)] text-black font-semibold px-4 py-2"
+      >
+        Zapisz profil
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/dashboard/SubscriptionsList.tsx
+++ b/frontend/src/components/dashboard/SubscriptionsList.tsx
@@ -1,0 +1,17 @@
+type Subscription = { fan: string; amount: number; period: string };
+
+export default function SubscriptionsList({ items }: { items: Subscription[] }) {
+  if (!items.length) return <p className="opacity-70">Brak subskrypcji.</p>;
+  return (
+    <div className="grid gap-2">
+      {items.map((s, i) => (
+        <div key={i} className="rounded-xl bg-white/5 border border-white/10 p-3 flex justify-between">
+          <span>@{s.fan}</span>
+          <span>
+            {s.amount} USDC / {s.period}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/TipStatistics.tsx
+++ b/frontend/src/components/dashboard/TipStatistics.tsx
@@ -1,0 +1,43 @@
+function Spark({ series }: { series: number[] }) {
+  const W = 240;
+  const H = 64;
+  const max = Math.max(1, ...series);
+  const pts = series
+    .map((v, i) => {
+      const x = (i / (series.length - 1)) * (W - 8) + 4;
+      const y = H - 4 - (v / max) * (H - 8);
+      return `${x},${y}`;
+    })
+    .join(' ');
+  return (
+    <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} role="img" aria-label="Wykres napiwków">
+      <polyline points={pts} fill="none" stroke="currentColor" strokeOpacity="0.8" strokeWidth="2" />
+    </svg>
+  );
+}
+
+export default function TipStatistics({
+  series,
+  total,
+  fans,
+}: {
+  series: number[];
+  total: number;
+  fans: number;
+}) {
+  return (
+    <section className="grid sm:grid-cols-3 gap-4">
+      <div className="rounded-2xl bg-white/5 border border-white/10 p-4">
+        <div className="text-sm opacity-80">Łącznie USDC</div>
+        <div className="text-2xl font-bold">{total}</div>
+      </div>
+      <div className="rounded-2xl bg-white/5 border border-white/10 p-4">
+        <div className="text-sm opacity-80">Liczba fanów</div>
+        <div className="text-2xl font-bold">{fans}</div>
+      </div>
+      <div className="rounded-2xl bg-white/5 border border-white/10 p-4 flex items-center justify-center">
+        <Spark series={series} />
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/WithdrawalForm.tsx
+++ b/frontend/src/components/dashboard/WithdrawalForm.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useState } from 'react';
+
+export default function WithdrawalForm({
+  balance,
+  onSubmit,
+}: {
+  balance: number;
+  onSubmit: (p: { amount: number; address: string }) => Promise<void> | void;
+}) {
+  const [amount, setAmount] = useState('');
+  const [address, setAddress] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    await onSubmit({ amount: Number(amount), address });
+    setLoading(false);
+  };
+
+  return (
+    <form onSubmit={submit} className="grid gap-3">
+      <div className="rounded-xl bg-white/5 border border-white/10 p-3">
+        <div className="text-sm opacity-80">Dostępne saldo</div>
+        <div className="text-xl font-bold">{balance.toFixed(2)} USDC</div>
+      </div>
+      <label className="grid gap-1">
+        <span className="text-sm opacity-80">Kwota</span>
+        <input
+          inputMode="decimal"
+          required
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="rounded-lg bg-white/5 border border-white/10 p-2"
+        />
+      </label>
+      <label className="grid gap-1">
+        <span className="text-sm opacity-80">Adres wypłaty (EOA)</span>
+        <input
+          required
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+          className="rounded-lg bg-white/5 border border-white/10 p-2"
+        />
+      </label>
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={loading}
+          aria-busy={loading}
+          className="rounded-lg bg-[var(--color-primary)] text-black font-semibold px-4 py-2"
+        >
+          Wypłać
+        </button>
+        <button
+          type="button"
+          onClick={() => setAmount(String(balance))}
+          className="rounded-lg border border-white/20 px-4 py-2"
+        >
+          Wypłać wszystko
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/ui/HeaderBar.tsx
+++ b/frontend/src/components/ui/HeaderBar.tsx
@@ -1,0 +1,10 @@
+export default function HeaderBar({ title, actions }: { title?: string; actions?: React.ReactNode }) {
+  return (
+    <header className="sticky top-0 z-10 bg-[var(--surface-2)]/75 backdrop-blur border-b border-white/10">
+      <div className="h-14 px-6 flex items-center justify-between">
+        <h1 className="text-lg font-semibold">{title}</h1>
+        <div>{actions}</div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/ui/Sidebar.tsx
+++ b/frontend/src/components/ui/Sidebar.tsx
@@ -1,0 +1,25 @@
+"use client";
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export default function Sidebar({ items }: { items: { href: string; label: string }[] }) {
+  const path = usePathname();
+  return (
+    <nav className="p-4 space-y-1">
+      {items.map((it) => {
+        const active = path === it.href;
+        return (
+          <Link
+            key={it.href}
+            href={it.href}
+            className={`block px-3 py-2 rounded-lg transition ${
+              active ? 'bg-primary text-black' : 'hover:bg-white/5 text-[var(--fg)]'
+            }`}
+          >
+            {it.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,3 +1,4 @@
 // Agregator UI — umożliwia import z `@/components/ui`
-export * from "./buttons";
-
+export * from './buttons';
+export { default as Sidebar } from './Sidebar';
+export { default as HeaderBar } from './HeaderBar';


### PR DESCRIPTION
## Summary
- add fan pages: feed, wallet, following, notifications, settings
- scaffold creator dashboard with layout and profile, goal, withdrawals, subscriptions pages
- introduce Sidebar, HeaderBar, and dashboard form components

## Testing
- `npm run lint` *(fails: unexpected any, etc.)*
- `npm test` *(fails: playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c69ea0c08327aec8a58b871a66e1