### PR TITLE
fix: backend build filters frontend and correct reminder query

### DIFF
--- a/backend/src/reminders/reminders.service.ts
+++ b/backend/src/reminders/reminders.service.ts
@@ -17,8 +17,11 @@ export class RemindersService {
     const users = await this.prisma.user.findMany({
       where: {
         published: false,
-        OR: [{ onboardingCompletedAt: null }],
-        OR: [{ lastOnboardingEmailAt: null }, { lastOnboardingEmailAt: { lt: since } }],
+        onboardingCompletedAt: null,
+        OR: [
+          { lastOnboardingEmailAt: null },
+          { lastOnboardingEmailAt: { lt: since } },
+        ],
       },
       select: { id: true, email: true, username: true },
     });

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -18,5 +18,5 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   },
-  "exclude": ["node_modules", "dist", "test", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "test", "frontend", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary
- exclude backend/frontend from ts compilation
- correct reminders query merging last email conditions

## Testing
- `cd backend && npm test` *(fails: Cannot find name 'AuthService', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ce10e59483278a9c2e908e6f49cb