### PR TITLE
feat: normalize API errors

### DIFF
--- a/frontend/src/components/TipForm.tsx
+++ b/frontend/src/components/TipForm.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import React, { useState } from "react";
-import apiClient from "@/lib/apiClient";
-import { useAuthStore } from "@/lib/stores/authStore";
+import React, { useState } from 'react';
+import apiClient from '@/lib/apiClient';
+import { normalize } from '@/lib/api/errors';
+import { useAuthStore } from '@/lib/stores/authStore';
 
 interface TipFormProps {
   /**
@@ -78,12 +79,9 @@ const TipForm: React.FC<TipFormProps> = ({ creatorId, onComplete }) => {
       setCustomAmount("");
       setMessage("");
       setIsAnonymous(false);
-    } catch (err: any) {
-      const msg =
-        err?.response?.data?.message ||
-        err?.message ||
-        "Nie udało się wysłać napiwku.";
-      setError(msg);
+    } catch (err: unknown) {
+      const { msg } = normalize(err as any);
+      setError(msg || 'Nie udało się wysłać napiwku.');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/WithdrawFundsModal.tsx
+++ b/frontend/src/components/WithdrawFundsModal.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
-import { apiClient } from "@/lib/apiClient";
+import { useState } from 'react';
+import { apiClient } from '@/lib/apiClient';
+import { normalize } from '@/lib/api/errors';
 
 interface WithdrawFundsModalProps {
   isOpen: boolean;
@@ -32,11 +33,10 @@ export default function WithdrawFundsModal({
         destinationAddress: address,
       });
       onClose();
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error(err);
-      setError(
-        err?.response?.data?.message || "Wystąpił błąd podczas wypłaty.",
-      );
+      const { msg } = normalize(err as any);
+      setError(msg || 'Wystąpił błąd podczas wypłaty.');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/auth/AuthForm.tsx
+++ b/frontend/src/components/auth/AuthForm.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import Image from "next/image";
-import { useForm, FormProvider } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { Eye, EyeOff, Mail, Lock } from "lucide-react";
-import apiClient from "@/lib/apiClient";
-import { registerSchema, RegisterFormValues } from "@/lib/schemas/authSchema";
-import axios from "axios";
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import { useForm, FormProvider } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Eye, EyeOff, Mail, Lock } from 'lucide-react';
+import apiClient from '@/lib/apiClient';
+import { normalize } from '@/lib/api/errors';
+import { registerSchema, RegisterFormValues } from '@/lib/schemas/authSchema';
 
 // import { useAuthStore } from "@/lib/stores/authStore";
 
@@ -43,16 +43,11 @@ export default function AuthForm() {
       setEmailSent(true);
       methods.reset();
     } catch (err: unknown) {
-      if (axios.isAxiosError(err) && err.response) {
-        if (err.response.status === 409) {
-          router.push("/login");
-        } else {
-          setApiError(
-            err.response.data?.message || "An unexpected error occurred.",
-          );
-        }
+      const { code, msg } = normalize(err as any);
+      if (code === 409) {
+        router.push('/login');
       } else {
-        setApiError("An unexpected error occurred during registration.");
+        setApiError(msg || 'An unexpected error occurred.');
       }
     } finally {
       setLoading(false);

--- a/frontend/src/components/onboarding/AuthStep.tsx
+++ b/frontend/src/components/onboarding/AuthStep.tsx
@@ -8,10 +8,11 @@ import { Eye, EyeOff, Mail, Lock, Wallet } from "lucide-react";
 import { SiweMessage } from "siwe";
 import { useAccount, useConnect, useSignMessage, useChainId } from "wagmi";
 
-import { useOnboardingStore } from "@/lib/stores/onboardingStore";
-import apiClient from "@/lib/apiClient";
-import { API } from "@/lib/api-routes";
-import { registerSchema, RegisterFormValues } from "@/lib/schemas/authSchema";
+import { useOnboardingStore } from '@/lib/stores/onboardingStore';
+import apiClient from '@/lib/apiClient';
+import { normalize } from '@/lib/api/errors';
+import { API } from '@/lib/api-routes';
+import { registerSchema, RegisterFormValues } from '@/lib/schemas/authSchema';
 
 export default function AuthStep() {
   const router = useRouter();
@@ -37,8 +38,9 @@ export default function AuthStep() {
       await apiClient.post('/auth/register', { email: data.email, password: data.password, role: currentRole });
       actions.setUserData({ email: data.email });
       actions.nextStep();
-    } catch (err: any) {
-      setApiError(err.response?.data?.message || "An unexpected error occurred.");
+    } catch (err: unknown) {
+      const { msg } = normalize(err as any);
+      setApiError(msg || 'An unexpected error occurred.');
     } finally {
       setLoading(false);
     }
@@ -98,8 +100,9 @@ export default function AuthStep() {
       actions.setTokens({ accessToken });
       actions.setUserData({ email: user.email, walletAddress: user.providerId, username: user.displayName });
       router.push("/choose-username");
-    } catch (err: any) {
-      setApiError(err.response?.data?.message || err.message || "Web3 registration failed.");
+    } catch (err: unknown) {
+      const { msg } = normalize(err as any);
+      setApiError(msg || 'Web3 registration failed.');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/lib/api/errors.ts
+++ b/frontend/src/lib/api/errors.ts
@@ -1,0 +1,19 @@
+export type HttpError = {
+  response?: {
+    status?: number;
+    data?: {
+      message?: string;
+      code?: number;
+      errors?: Record<string, any>;
+    };
+  };
+  message?: string;
+};
+
+export function normalize(err: HttpError) {
+  const code = err.response?.status;
+  const msg =
+    err.response?.data?.message || err.message || 'Unexpected error';
+  const fields = err.response?.data?.errors;
+  return { code, msg, fields };
+}


### PR DESCRIPTION
## Summary
- add `normalize` helper for API error handling
- refactor TipForm, AuthForm, AuthStep, WithdrawFundsModal to use normalized errors

## Testing
- `npm test` *(fails: Protocol error: Cannot navigate to invalid URL)*
- `npm run lint` *(fails: parsing errors and unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fcf7a0388327b285cd6a6cc27dae