### PR TITLE
feat(ui): add async boundary components

### DIFF
--- a/frontend/src/components/ui/AsyncBoundary.tsx
+++ b/frontend/src/components/ui/AsyncBoundary.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Component, ReactNode, Suspense } from 'react';
+import ErrorState from './ErrorState';
+
+interface Props {
+  fallback: ReactNode;
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+class Boundary extends Component<{ children: ReactNode }, State> {
+  state: State = { error: null };
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+  handleRetry = () => {
+    this.setState({ error: null });
+  };
+  render() {
+    const { error } = this.state;
+    if (error) {
+      return <ErrorState message={error.message} onRetry={this.handleRetry} />;
+    }
+    return this.props.children;
+  }
+}
+
+export default function AsyncBoundary({ fallback, children }: Props) {
+  return (
+    <Boundary>
+      <Suspense fallback={fallback}>{children}</Suspense>
+    </Boundary>
+  );
+}

--- a/frontend/src/components/ui/ErrorState.tsx
+++ b/frontend/src/components/ui/ErrorState.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Button } from './Button';
+
+export default function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div
+      role="alert"
+      className="flex flex-col items-center gap-4 rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-center"
+    >
+      <p className="text-sm text-red-200">{message}</p>
+      <Button variant="secondary" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/LoadingSkeleton.tsx
+++ b/frontend/src/components/ui/LoadingSkeleton.tsx
@@ -1,0 +1,11 @@
+import Skeleton from './Skeleton';
+
+export default function LoadingSkeleton({ lines = 3 }: { lines?: number }) {
+  return (
+    <div aria-hidden className="space-y-2">
+      {Array.from({ length: lines }).map((_, i) => (
+        <Skeleton key={i} className="h-4 w-full" />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -2,3 +2,6 @@
 export * from './buttons';
 export { default as Sidebar } from './Sidebar';
 export { default as HeaderBar } from './HeaderBar';
+export { default as LoadingSkeleton } from './LoadingSkeleton';
+export { default as ErrorState } from './ErrorState';
+export { default as AsyncBoundary } from './AsyncBoundary';


### PR DESCRIPTION
## Summary
- add `LoadingSkeleton` for configurable placeholder lines
- add reusable `ErrorState` and `AsyncBoundary` for async flows
- export new ui helpers from aggregator

## Testing
- `npm run lint` *(fails: multiple existing lint errors)*
- `npm test` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fcfd2aa48327871925b07b3eb69a