### PR TITLE
feat(frontend): add creator profile component

### DIFF
--- a/frontend/src/app/creators/[alias]/page.tsx
+++ b/frontend/src/app/creators/[alias]/page.tsx
@@ -1,4 +1,77 @@
+"use client";
 
+import { useEffect } from "react";
+import { useParams } from "next/navigation";
+import LoadingSkeleton from "@/components/LoadingSkeleton";
+import ErrorState from "@/components/ErrorState";
+import TipLauncher from "@/components/TipLauncher";
+import { useCreator } from "@/hooks/useCreator";
+import { useQuery } from "@tanstack/react-query";
+import { getCreatorTips } from "@/lib/tips";
+import { track } from "@/lib/analytics";
+
+export default function CreatorProfilePage() {
+  const { alias } = useParams<{ alias: string }>();
+
+  const {
+    data: creator,
+    isLoading: creatorLoading,
+    error: creatorError,
+  } = useCreator(alias);
+
+  const {
+    data: tips,
+    isLoading: tipsLoading,
+    error: tipsError,
+  } = useQuery({
+    queryKey: ["tips", alias],
+    queryFn: () => getCreatorTips(alias),
+    enabled: !!alias,
+  });
+
+  useEffect(() => {
+    if (alias) track("view_profile", { alias });
+  }, [alias]);
+
+  if (creatorLoading || tipsLoading) {
+    return <LoadingSkeleton />;
+  }
+
+  if (creatorError || tipsError || !creator) {
+    return <ErrorState message="Profile not found" />;
+  }
+
+  return (
+    <main className="min-h-screen bg-[#001F1F] p-6 text-white">
+      <div className="mx-auto max-w-3xl">
+        <div className="flex items-center gap-4">
+          <img
+            src={creator.avatarUrl || "/placeholder_light_gray_block.png"}
+            alt={creator.displayName || alias}
+            className="h-24 w-24 rounded-full object-cover"
+          />
+          <div>
+            <h1 className="text-2xl font-semibold">{creator.displayName || alias}</h1>
+            <p className="text-teal-400">@{creator.username || alias}</p>
+          </div>
+        </div>
+        {creator.profile?.bio && (
+          <p className="mt-4 text-white/80">{creator.profile.bio}</p>
+        )}
+        <div className="mt-6">
+          <TipLauncher username={alias} />
+        </div>
+        {Array.isArray(tips) && tips.length > 0 && (
+          <div className="mt-8">
+            <h2 className="text-xl font-semibold">Recent tips</h2>
+            <ul className="mt-4 space-y-2 text-sm text-white/80">
+              {tips.map((t: any, i: number) => (
+                <li key={i}>{t.amount} USDC</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </main>
   );
 }
-

--- a/frontend/src/app/tip/[handle]/success/page.tsx
+++ b/frontend/src/app/tip/[handle]/success/page.tsx
@@ -1,5 +1,8 @@
+"use client";
+import { useEffect } from "react";
 import Receipt from "@/components/tip/Receipt";
 import Link from "next/link";
+import { track } from "@/lib/analytics";
 
 export default function Page({
   params,
@@ -11,6 +14,12 @@ export default function Page({
   const handle = params.handle;
   const amount = normAmt(searchParams?.amt);
   const tx = String(searchParams?.tx || "");
+
+  useEffect(() => {
+    if (amount && tx) {
+      track("tip_success", { alias: handle, amount, tx });
+    }
+  }, [amount, tx, handle]);
 
   if (!amount || !tx) {
     return (

--- a/frontend/src/components/ErrorState.tsx
+++ b/frontend/src/components/ErrorState.tsx
@@ -1,0 +1,3 @@
+export default function ErrorState({ message = "Something went wrong." }: { message?: string }) {
+  return <div className="p-6 text-center text-red-400">{message}</div>;
+}

--- a/frontend/src/components/LoadingSkeleton.tsx
+++ b/frontend/src/components/LoadingSkeleton.tsx
@@ -1,0 +1,17 @@
+import Skeleton from "@/components/ui/Skeleton";
+
+export default function LoadingSkeleton() {
+  return (
+    <div className="p-6 space-y-4">
+      <Skeleton className="h-48 w-full" />
+      <div className="flex items-center gap-4">
+        <Skeleton className="h-24 w-24 rounded-full" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-6 w-40" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+      </div>
+      <Skeleton className="h-20 w-full" />
+    </div>
+  );
+}

--- a/frontend/src/components/TipLauncher.tsx
+++ b/frontend/src/components/TipLauncher.tsx
@@ -1,15 +1,22 @@
 'use client';
 import { useState } from 'react';
 import TipModal from './TipModal';
+import { track } from '@/lib/analytics';
 
 export default function TipLauncher({ username }:{ username:string }) {
   const [open, setOpen] = useState(false);
   return (
     <>
-      <button onClick={()=>setOpen(true)} className="px-5 py-3 rounded-xl bg-[#FFD700] text-[#003737] font-bold">
+      <button
+        onClick={() => {
+          track('tap_tip', { alias: username });
+          setOpen(true);
+        }}
+        className="px-5 py-3 rounded-xl bg-[#FFD700] text-[#003737] font-bold"
+      >
         Tip USDC
       </button>
-      <TipModal username={username} open={open} onClose={()=>setOpen(false)} />
+      <TipModal username={username} open={open} onClose={() => setOpen(false)} />
     </>
   );
 }

--- a/frontend/src/hooks/useCreator.ts
+++ b/frontend/src/hooks/useCreator.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getPublicProfile } from "@/lib/users";
+
+export function useCreator(alias: string) {
+  return useQuery({
+    queryKey: ["creator", alias],
+    queryFn: () => getPublicProfile(alias),
+    enabled: !!alias,
+  });
+}

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -13,3 +13,16 @@ export async function trackOnboarding(
   }
 }
 
+export async function track(event: string, data?: Record<string, unknown>) {
+  try {
+    await fetch('/api/v1/analytics', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ event, data }),
+      keepalive: true,
+    });
+  } catch {
+    // silent
+  }
+}
+

--- a/frontend/src/lib/tips.ts
+++ b/frontend/src/lib/tips.ts
@@ -24,3 +24,8 @@ export async function sendTip(payload: TipPayload, guest?: GuestExtras) {
     return { tip, guest: true };
   }
 }
+
+export async function getCreatorTips(alias: string) {
+  const path = `/api/v1/creators/${encodeURIComponent(alias)}/tips`;
+  return http(path, { method: "GET" });
+}


### PR DESCRIPTION
## Summary
- add creator profile page with creator and tips queries
- implement analytics tracking for profile view and tipping
- introduce loading and error states

## Testing
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fd017c808327b011c46d1c6006ad