### PR TITLE
feat(frontend): track learn article view

### DIFF
--- a/frontend/src/app/learn/page.tsx
+++ b/frontend/src/app/learn/page.tsx
@@ -1,4 +1,29 @@
+import { useEffect } from 'react';
 
+import { track } from '@/lib/analytics';
+
+export default function LearnPage() {
+  useEffect(() => {
+    track('view_learn_article');
+  }, []);
+
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <article className="prose">
+        <h1 className="text-3xl font-bold">Learn about TipJar</h1>
+        <p>
+          TipJar helps creators receive support from their audience through simple
+          tipping experiences. This article explains the basics so you can get
+          started quickly.
+        </p>
+        <p>
+          After creating an account, share your TipJar link with fans. They can
+          send tips in a few clicks, and you&apos;ll see them in your dashboard.
+          Explore additional features like goal tracking and community rewards to
+          keep your supporters engaged.
+        </p>
+      </article>
+    </main>
   );
 }
 

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -1,3 +1,18 @@
+type Analytics = {
+  track: (event: string, properties: Record<string, unknown>) => void;
+};
+
+export function track(event: string, properties: Record<string, unknown> = {}) {
+  try {
+    if (typeof window !== 'undefined') {
+      const analyticsWindow = window as Window & { analytics?: Analytics };
+      analyticsWindow.analytics?.track(event, properties);
+    }
+  } catch {
+    // silent
+  }
+}
+
 export async function trackOnboarding(
   step: 'identity' | 'bio' | 'tiers' | 'payments' | 'publish',
   action: 'view' | 'save' | 'error' | 'complete',


### PR DESCRIPTION
## Summary
- add static learn article content
- send analytics event `view_learn_article` on page mount

## Testing
- `npx eslint src/app/learn/page.tsx src/lib/analytics.ts`
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fd06a6fc83279925d526d8c97d0b