### PR TITLE
feat(frontend): add creator profile components and tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "lint": "next lint",
     "clean": "rm -rf .next",
-    "test": "vitest",
+    "test": "vitest --environment jsdom",
     "test:e2e": "playwright test"
   },
   "dependencies": {
@@ -62,6 +62,10 @@
     "typescript": "^5.5.2",
     "vite": "^6.3.5",
     "@playwright/test": "^1.51.1",
-    "vitest": "^2.1.4"
+    "vitest": "^2.1.4",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.8.0",
+    "jsdom": "^26.1.0"
   }
 }

--- a/frontend/src/app/(creator)/[handle]/page.tsx
+++ b/frontend/src/app/(creator)/[handle]/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useMemo } from 'react';
+import ProfileHero from '@/components/profile/ProfileHero';
+import SupportTierCard from '@/components/profile/SupportTierCard';
+import TipModule from '@/components/profile/TipModule';
+import ContentGrid from '@/components/profile/ContentGrid';
+import CommunitySection from '@/components/profile/CommunitySection';
+import StickyCtaDock from '@/components/profile/StickyCtaDock';
+import data from '@/data/profile.seed.json';
+
+type PageProps = { params: { handle: string } };
+
+export default function CreatorProfilePage({ params }: PageProps) {
+  const profile = useMemo(() => (data as any[]).find((p) => p.handle === params.handle), [params.handle]);
+
+  if (!profile) {
+    return (
+      <main className="mx-auto max-w-6xl px-4 py-10">
+        <h1 className="text-xl font-semibold text-[#DDE0DA]">Profile not found</h1>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-8 md:px-6">
+      <ProfileHero
+        name={profile.name}
+        handle={profile.handle}
+        tagline={profile.tagline}
+        portraitUrl={profile.portraitUrl}
+        bannerUrl={profile.bannerUrl}
+        onPrimaryHref={`/tip/${profile.handle}`}
+        onSecondaryHref={`/follow/${profile.handle}`}
+      />
+
+      {/* Monetization rows */}
+      <section className="mt-8 grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* Tiers */}
+        <div className="lg:col-span-2">
+          <h2 className="mb-3 text-base font-semibold text-[#DDE0DA]">Membership tiers</h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {profile.tiers.map((t: any) => (
+              <SupportTierCard key={t.id} tier={t} onSelect={() => { /* hook into checkout */ }} />
+            ))}
+          </div>
+
+          <h2 className="mt-8 mb-3 text-base font-semibold text-[#DDE0DA]">Recent posts</h2>
+          <ContentGrid items={profile.posts} />
+        </div>
+
+        {/* Tips + community */}
+        <aside className="space-y-6">
+          <TipModule
+            currency={profile.currency || 'USD'}
+            onSubmit={(amount) => {
+              // Hook point for payments. Demo only:
+              alert(`Tipping ${amount} ${profile.currency || 'USD'} to ${profile.name}`);
+            }}
+          />
+          <CommunitySection links={profile.communityLinks} />
+        </aside>
+      </section>
+
+      {/* Sticky CTA for mobile */}
+      <StickyCtaDock href={`/tip/${profile.handle}`} />
+    </main>
+  );
+}

--- a/frontend/src/components/profile/CommunitySection.tsx
+++ b/frontend/src/components/profile/CommunitySection.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+const TEXT_PRIMARY = '#DDE0DA';
+const TEXT_SECONDARY = '#BCC1B6';
+
+type Props = {
+  links?: { label: string; href: string }[];
+};
+
+export default function CommunitySection({ links = [] }: Props) {
+  return (
+    <section className="rounded-2xl border border-[rgba(255,215,0,0.12)] bg-[rgba(0,55,55,0.85)] p-5">
+      <h2 className="text-lg font-semibold" style={{ color: TEXT_PRIMARY }}>Community</h2>
+      <p className="mt-1 text-sm" style={{ color: TEXT_SECONDARY }}>
+        Join the discussion and connect with other fans.
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {links.length ? (
+          links.map((l) => (
+            <a
+              key={l.href}
+              href={l.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-[12px] border border-[#FFD700CC] px-3 py-1.5 text-sm text-[#FFD700] transition hover:bg-[rgba(255,215,0,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(255,215,0,0.70)]"
+            >
+              {l.label}
+            </a>
+          ))
+        ) : (
+          <span className="text-sm" style={{ color: TEXT_SECONDARY }}>No links yet.</span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/profile/ContentGrid.tsx
+++ b/frontend/src/components/profile/ContentGrid.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Image from 'next/image';
+
+type Item = {
+  id: string;
+  title: string;
+  coverUrl?: string | null;
+  locked?: boolean;
+};
+
+type Props = {
+  items: Item[];
+};
+
+const TEXT_PRIMARY = '#DDE0DA';
+const TEXT_SECONDARY = '#BCC1B6';
+const GOLD = '#FFD700';
+
+export default function ContentGrid({ items }: Props) {
+  if (!items.length) {
+    return <p className="text-sm" style={{ color: TEXT_SECONDARY }}>No posts yet.</p>;
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+      {items.map((it) => (
+        <article key={it.id} className="overflow-hidden rounded-2xl border border-[rgba(255,215,0,0.12)] bg-[rgba(0,55,55,0.85)]">
+          <div className="relative h-40 w-full">
+            {it.coverUrl ? (
+              <Image src={it.coverUrl} alt="" fill sizes="33vw" className="object-cover" />
+            ) : (
+              <div className="h-full w-full bg-[rgba(0,55,55,0.6)]" aria-hidden />
+            )}
+            {it.locked && (
+              <span className="absolute right-3 top-3 rounded-full bg-[rgba(255,215,0,0.12)] px-2 py-0.5 text-xs font-semibold" style={{ color: GOLD }}>
+                Premium
+              </span>
+            )}
+          </div>
+          <h3 className="truncate p-4 text-sm font-medium" style={{ color: TEXT_PRIMARY }}>
+            {it.title}
+          </h3>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/ProfileHero.tsx
+++ b/frontend/src/components/profile/ProfileHero.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import Image from 'next/image';
+import PrimaryCta from '@/components/cta/PrimaryCta';
+import SecondaryCta from '@/components/cta/SecondaryCta';
+
+type Props = {
+  name: string;
+  handle: string;
+  tagline?: string;
+  portraitUrl?: string | null;
+  bannerUrl?: string | null;
+  onPrimaryHref?: string;   // e.g., /tip/[handle]
+  onSecondaryHref?: string; // e.g., /follow/[handle]
+};
+
+const TEXT_PRIMARY = '#DDE0DA';
+const TEXT_SECONDARY = '#BCC1B6';
+
+export default function ProfileHero({
+  name,
+  handle,
+  tagline,
+  portraitUrl,
+  bannerUrl,
+  onPrimaryHref = '#',
+  onSecondaryHref = '#',
+}: Props) {
+  return (
+    <section className="relative isolate overflow-hidden rounded-2xl border border-[rgba(255,215,0,0.12)]">
+      {/* Banner */}
+      <div className="relative h-56 w-full sm:h-64">
+        {/* Placeholder if missing */}
+        {bannerUrl ? (
+          <Image src={bannerUrl} alt="" fill sizes="100vw" className="object-cover" priority />
+        ) : (
+          <div className="h-full w-full bg-[rgba(0,55,55,0.8)]" aria-hidden />
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-[rgba(0,0,0,0.55)] via-transparent to-[rgba(0,0,0,0.15)]" />
+      </div>
+
+      {/* Info row */}
+      <div className="relative -mt-10 flex flex-col gap-4 px-5 pb-5 sm:-mt-12 sm:flex-row sm:items-end sm:justify-between sm:px-6">
+        {/* Portrait */}
+        <div className="flex items-end gap-4">
+          <div className="relative h-24 w-24 overflow-hidden rounded-xl border border-[rgba(255,215,0,0.16)] bg-[rgba(0,55,55,0.9)]">
+            {portraitUrl ? (
+              <Image src={portraitUrl} alt={`${name} portrait`} fill sizes="96px" className="object-cover" />
+            ) : (
+              <div className="grid h-full w-full place-items-center" aria-hidden>
+                <span className="text-sm" style={{ color: TEXT_SECONDARY }}>—</span>
+              </div>
+            )}
+          </div>
+          <div className="pb-2">
+            <h1 className="text-2xl font-semibold" style={{ color: TEXT_PRIMARY }}>{name}</h1>
+            <p className="text-sm" style={{ color: TEXT_SECONDARY }}>@{handle}</p>
+            {tagline && <p className="mt-1 max-w-xl text-sm" style={{ color: TEXT_PRIMARY }}>{tagline}</p>}
+          </div>
+        </div>
+
+        {/* CTAs */}
+        <div className="flex items-center gap-3 pb-2">
+          <PrimaryCta href={onPrimaryHref}>Support Now</PrimaryCta>
+          <SecondaryCta href={onSecondaryHref}>Follow</SecondaryCta>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/profile/StickyCtaDock.tsx
+++ b/frontend/src/components/profile/StickyCtaDock.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import PrimaryCta from '@/components/cta/PrimaryCta';
+
+type Props = {
+  label?: string;
+  href?: string;
+};
+
+export default function StickyCtaDock({ label = 'Support Now', href = '#' }: Props) {
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 border-t border-[rgba(255,215,0,0.12)] bg-[rgba(0,55,55,0.92)]/95 p-3 backdrop-blur-sm sm:hidden">
+      <div className="mx-auto max-w-3xl">
+        <PrimaryCta href={href}>{label}</PrimaryCta>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/profile/SupportTierCard.tsx
+++ b/frontend/src/components/profile/SupportTierCard.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import clsx from 'clsx';
+
+type Tier = {
+  id: string;
+  name: string;           // e.g., "Silver"
+  priceMonthly: number;   // e.g., 5
+  perks: string[];        // bullet list
+  recommended?: boolean;
+};
+
+type Props = {
+  tier: Tier;
+  onSelect?: (tierId: string) => void;
+};
+
+const TEXT_PRIMARY = '#DDE0DA';
+const TEXT_SECONDARY = '#BCC1B6';
+const GOLD = '#FFD700';
+
+export default function SupportTierCard({ tier, onSelect }: Props) {
+  const { id, name, priceMonthly, perks, recommended } = tier;
+
+  return (
+    <div
+      className={clsx(
+        'relative flex h-full flex-col justify-between rounded-2xl border p-5',
+        'border-[rgba(255,215,0,0.12)] bg-[rgba(0,55,55,0.85)] backdrop-blur-sm',
+        recommended && 'ring-1 ring-[rgba(255,215,0,0.35)]'
+      )}
+      aria-label={`${name} tier`}
+    >
+      {recommended && (
+        <span
+          className="absolute right-4 top-4 rounded-full px-2 py-0.5 text-xs font-semibold"
+          style={{ background: 'rgba(255,215,0,0.12)', color: GOLD }}
+        >
+          Recommended
+        </span>
+      )}
+
+      <div>
+        <h3 className="text-lg font-semibold" style={{ color: TEXT_PRIMARY }}>{name}</h3>
+        <p className="mt-1 text-sm" style={{ color: TEXT_SECONDARY }}>
+          ${priceMonthly}/mo
+        </p>
+
+        <ul className="mt-4 space-y-2">
+          {perks.map((p) => (
+            <li key={p} className="text-sm" style={{ color: TEXT_PRIMARY }}>
+              • {p}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onSelect?.(id)}
+        className="mt-5 inline-flex items-center justify-center rounded-[12px] border border-[#FFD700CC] px-4 py-2 text-sm font-medium text-[#FFD700] transition hover:bg-[rgba(255,215,0,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(255,215,0,0.70)]"
+        aria-label={`Choose ${name} at $${priceMonthly} per month`}
+      >
+        Become a Member
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/profile/TipModule.tsx
+++ b/frontend/src/components/profile/TipModule.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useId, useState } from 'react';
+
+type Props = {
+  presets?: number[]; // default [5,10,25]
+  currency?: 'USD' | 'EUR' | 'GBP';
+  onSubmit?: (amount: number, currency: Props['currency']) => Promise<void> | void;
+};
+
+const TEXT_PRIMARY = '#DDE0DA';
+const TEXT_SECONDARY = '#BCC1B6';
+const GOLD = '#FFD700';
+
+export default function TipModule({ presets = [5, 10, 25], currency = 'USD', onSubmit }: Props) {
+  const formId = useId();
+  const [amount, setAmount] = useState<number | ''>('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fmt = (n: number) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(n);
+
+  const valid = typeof amount === 'number' && amount > 0 && amount <= 10000;
+
+  return (
+    <form
+      aria-labelledby={`${formId}-title`}
+      onSubmit={async (e) => {
+        e.preventDefault();
+        if (!valid || loading) return;
+        try {
+          setLoading(true);
+          setError(null);
+          await onSubmit?.(amount as number, currency);
+        } catch (_err: unknown) {
+          setError('Something went wrong.');
+        } finally {
+          setLoading(false);
+        }
+      }}
+      className="rounded-2xl border border-[rgba(255,215,0,0.12)] bg-[rgba(0,55,55,0.85)] p-5 backdrop-blur-sm"
+    >
+      <h2 id={`${formId}-title`} className="text-lg font-semibold" style={{ color: TEXT_PRIMARY }}>
+        Send a tip
+      </h2>
+      <p className="mt-1 text-sm" style={{ color: TEXT_SECONDARY }}>
+        Choose an amount or enter your own.
+      </p>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {presets.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => setAmount(p)}
+            className={`rounded-full border px-3 py-1.5 text-sm transition ${amount === p ? 'border-[#FFD700] text-[#FFD700]' : 'border-[rgba(255,215,0,0.20)] text-[#DDE0DA] hover:bg-[rgba(255,215,0,0.08)]'}`}
+            aria-pressed={amount === p}
+            aria-label={`Tip ${fmt(p)}`}
+          >
+            {fmt(p)}
+          </button>
+        ))}
+      </div>
+
+      <label htmlFor={`${formId}-custom`} className="mt-4 block text-sm" style={{ color: TEXT_PRIMARY }}>
+        Custom amount
+      </label>
+      <div className="mt-1 flex items-center gap-2">
+        <input
+          id={`${formId}-custom`}
+          inputMode="decimal"
+          pattern="[0-9]+([.,][0-9]{1,2})?"
+          placeholder="e.g. 7.00"
+          className="w-40 rounded-xl border border-[rgba(255,215,0,0.18)] bg-[rgba(0,55,55,0.6)] px-3 py-2 text-base text-[#DDE0DA] placeholder-[#BCC1B6] outline-none focus-visible:ring-2 focus-visible:ring-[rgba(255,215,0,0.70)]"
+          onChange={(e) => {
+            const v = e.target.value.replace(',', '.');
+            const n = Number(v);
+            setAmount(Number.isFinite(n) ? n : '');
+          }}
+          value={typeof amount === 'number' ? String(amount) : ''}
+          aria-invalid={!valid && amount !== '' ? true : undefined}
+        />
+        <span className="text-sm" style={{ color: TEXT_SECONDARY }}>
+          {currency}
+        </span>
+      </div>
+
+      {error && (
+        <p role="alert" className="mt-2 text-sm" style={{ color: GOLD }}>
+          {error}
+        </p>
+      )}
+
+      <div className="mt-5">
+        <button
+          type="submit"
+          disabled={!valid || loading}
+          className="inline-flex items-center justify-center gap-2 rounded-full bg-[#FFD700] px-5 py-2.5 text-sm font-semibold text-[#0B0F12] shadow-[0_6px_16px_rgba(255,215,0,0.18)] transition hover:bg-[#E6C200] active:bg-[#C9A500] disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(255,215,0,0.70)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#003737]"
+          aria-busy={loading || undefined}
+        >
+          {loading && <span aria-hidden className="h-4 w-4 animate-spin rounded-full border-2 border-[#0B0F12] border-t-transparent" />}
+          <span>Tip Now</span>
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/profile/__tests__/SupportTierCard.test.tsx
+++ b/frontend/src/components/profile/__tests__/SupportTierCard.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SupportTierCard from '../SupportTierCard';
+
+describe('SupportTierCard', () => {
+  it('renders name, price and perks, triggers onSelect', () => {
+    const onSelect = vi.fn();
+    render(
+      <SupportTierCard
+        onSelect={onSelect}
+        tier={{
+          id: 't1',
+          name: 'Silver',
+          priceMonthly: 5,
+          perks: ['Early access', 'Behind-the-scenes'],
+          recommended: true,
+        }}
+      />
+    );
+    expect(screen.getByLabelText(/silver tier/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /choose silver/i }));
+    expect(onSelect).toHaveBeenCalledWith('t1');
+  });
+});

--- a/frontend/src/components/profile/__tests__/TipModule.test.tsx
+++ b/frontend/src/components/profile/__tests__/TipModule.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import TipModule from '../TipModule';
+afterEach(() => {
+  cleanup();
+});
+
+
+describe('TipModule', () => {
+  it('selects preset and submits', async () => {
+    const onSubmit = vi.fn();
+    render(<TipModule presets={[5, 10]} currency="USD" onSubmit={onSubmit} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Tip $10.00' }));
+    const submit = screen.getByRole('button', { name: /tip now/i });
+    expect(submit).toBeEnabled();
+    fireEvent.click(submit);
+    expect(onSubmit).toHaveBeenCalledWith(10, 'USD');
+  });
+
+  it('validates custom amount', () => {
+    render(<TipModule />);
+    const input = screen.getByLabelText(/custom amount/i);
+    fireEvent.change(input, { target: { value: '0' } });
+    const submit = screen.getByRole('button', { name: /tip now/i });
+    expect(submit).toBeDisabled();
+  });
+});

--- a/frontend/src/data/profile.seed.json
+++ b/frontend/src/data/profile.seed.json
@@ -1,0 +1,22 @@
+[
+  {
+    "handle": "janedoe",
+    "name": "Jane Doe",
+    "tagline": "Illustrator & storyteller",
+    "portraitUrl": null,
+    "bannerUrl": null,
+    "currency": "USD",
+    "tiers": [
+      { "id": "t1", "name": "Silver", "priceMonthly": 5, "perks": ["Early access", "Behind-the-scenes"] },
+      { "id": "t2", "name": "Gold", "priceMonthly": 10, "perks": ["All Silver perks", "Exclusive downloads"], "recommended": true }
+    ],
+    "posts": [
+      { "id": "p1", "title": "Sketchbook drop — September", "coverUrl": null, "locked": false },
+      { "id": "p2", "title": "Character pack (WIP)", "coverUrl": null, "locked": true }
+    ],
+    "communityLinks": [
+      { "label": "Discord", "href": "https://example.com/discord" },
+      { "label": "Twitter/X", "href": "https://example.com/twitter" }
+    ]
+  }
+]

--- a/frontend/src/hooks/useBodyScrollLock.ts
+++ b/frontend/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/** Locks <body> scroll when `locked` = true (mobile sheets/modals). */
+export function useBodyScrollLock(locked: boolean) {
+  useEffect(() => {
+    const { body } = document;
+    if (!body) return;
+    const prev = body.style.overflow;
+    if (locked) body.style.overflow = 'hidden';
+    return () => {
+      body.style.overflow = prev;
+    };
+  }, [locked]);
+}
+export default useBodyScrollLock;

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -2,8 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'node',
-    include: ['src/**/*.spec.ts'],
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'src/**/*.spec.ts', 'src/**/*.spec.tsx'],
     exclude: ['tests/**/*'],
+    setupFiles: ['./vitest.setup.ts'],
+  },
+  esbuild: {
+    jsx: 'automatic',
   },
 });

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- implement scroll lock hook and new creator profile UI components
- add sample profile page with seed data and supporting tests
- configure vitest for jsdom and testing-library utilities

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run lint` *(fails: Unexpected any, missing types, and other repo-wide lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b404adc2a483279c155a6b4e713b33